### PR TITLE
fix: Reduce multiplayer lag

### DIFF
--- a/src/gun.ts
+++ b/src/gun.ts
@@ -9,10 +9,6 @@ import {
   Animator,
   MeshRenderer,
   Material,
-  MeshCollider,
-  TriggerArea,
-  triggerAreaEventsSystem,
-  ColliderLayer,
   Schemas
 } from '@dcl/sdk/ecs'
 import { Vector3, Quaternion, Color4, Color3 } from '@dcl/sdk/math'
@@ -41,6 +37,8 @@ const SHOOT_ANIM_FREEZE_DURATION = 0.4
 // Bullet flies straight; remove after this distance from spawn (out of scene)
 const BULLET_MAX_DISTANCE = 40
 const GUN_SYSTEM_PRIORITY_LAST = -1000
+const PROJECTILE_HIT_RADIUS = 0.95
+const PROJECTILE_HIT_RADIUS_SQ = PROJECTILE_HIT_RADIUS * PROJECTILE_HIT_RADIUS
 
 // Unparented gun: we set position and rotation every frame (lerp/slerp to reduce jitter). Bullet spawns at exact gunWorldPos/gunWorldRot.
 const GUN_POSITION_SMOOTH_SPEED = 12
@@ -53,10 +51,6 @@ const ProjectileComponentSchema = {
   canDamage: Schemas.Boolean
 }
 export const ProjectileComponent = engine.defineComponent('ProjectileComponent', ProjectileComponentSchema)
-
-// Tag: zombie already has a bullet trigger area (so we add it only once)
-const ZombieBulletTriggerSchema = {}
-const ZombieBulletTriggerTag = engine.defineComponent('ZombieBulletTriggerTag', ZombieBulletTriggerSchema)
 
 let gunEntity: Entity | null = null
 let shootTimer = 0
@@ -130,10 +124,6 @@ function spawnProjectile(
     startPosition: Vector3.clone(spawnPos),
     canDamage
   })
-  if (canDamage) {
-    // Bullets need a collider so they trigger zombie TriggerAreas
-    MeshCollider.setSphere(projectile, ColliderLayer.CL_CUSTOM1)
-  }
   return direction
 }
 
@@ -193,38 +183,25 @@ function projectileSystem(dt: number) {
 
     const mutableTransform = Transform.getMutable(projectile)
     mutableTransform.position = newPos
-  }
-}
 
-// One-time setup: add a TriggerArea to each zombie so bullets (MeshCollider CL_CUSTOM1) trigger hit
-function zombieBulletTriggerSetupSystem() {
-  for (const [zombie] of engine.getEntitiesWith(ZombieComponent, Transform)) {
-    if (ZombieBulletTriggerTag.has(zombie)) continue
+    if (!projData.canDamage) continue
 
-    const triggerChild = engine.addEntity()
-    Transform.create(triggerChild, {
-      parent: zombie,
-      position: Vector3.create(0, ZOMBIE_TARGET_HEIGHT, 0),
-      scale: Vector3.create(2, 2, 2),
-      rotation: Quaternion.Identity()
-    })
-    TriggerArea.setSphere(triggerChild, ColliderLayer.CL_CUSTOM1)
-    triggerAreaEventsSystem.onTriggerEnter(triggerChild, (result) => {
-      const areaEntity = result.triggeredEntity as Entity
-      const bulletEntity = result.trigger?.entity as Entity | undefined
-      if (bulletEntity == null || !ProjectileComponent.has(bulletEntity)) return
-      const projectileData = ProjectileComponent.get(bulletEntity)
-      if (!projectileData.canDamage) return
-      const zombieEntity = Transform.has(areaEntity) ? (Transform.get(areaEntity).parent as Entity) : null
-      if (zombieEntity == null || !ZombieComponent.has(zombieEntity)) return
-      const rewardAnchor = Vector3.clone(Transform.get(zombieEntity).position)
-      if (damageZombie(zombieEntity, 1)) {
+    for (const [zombie] of engine.getEntitiesWith(ZombieComponent, Transform)) {
+      const zombiePos = Transform.get(zombie).position
+      const dx = newPos.x - zombiePos.x
+      const dy = newPos.y - (zombiePos.y + ZOMBIE_TARGET_HEIGHT)
+      const dz = newPos.z - zombiePos.z
+      const distSq = dx * dx + dy * dy + dz * dz
+      if (distSq > PROJECTILE_HIT_RADIUS_SQ) continue
+
+      const rewardAnchor = Vector3.clone(zombiePos)
+      if (damageZombie(zombie, 1)) {
         addZombieCoins(COINS_PER_KILL)
         spawnZcRewardTextAtPosition(rewardAnchor, COINS_PER_KILL)
       }
-      engine.removeEntity(bulletEntity)
-    })
-    ZombieBulletTriggerTag.create(zombie)
+      engine.removeEntity(projectile)
+      break
+    }
   }
 }
 
@@ -299,7 +276,6 @@ export function spawnReplicatedGunShotVisual(origin: Vector3, direction: Vector3
 }
 
 export function initGunSystems() {
-  engine.addSystem(zombieBulletTriggerSetupSystem)
   engine.addSystem(projectileSystem)
   engine.addSystem(gunSystem, GUN_SYSTEM_PRIORITY_LAST, 'gunSystem')
 }

--- a/src/healthBar.ts
+++ b/src/healthBar.ts
@@ -15,7 +15,8 @@ const HealthBarSchema = {
   maxHp: Schemas.Number,
   isPlayer: Schemas.Boolean,
   /** Height above parent feet (y offset). Used for zombies; player bar uses Transform parent + local position. */
-  heightOffset: Schemas.Number
+  heightOffset: Schemas.Number,
+  lastStyleVariant: Schemas.Number
 }
 const HealthBarComponent = engine.defineComponent('HealthBarComponent', HealthBarSchema)
 
@@ -66,7 +67,7 @@ export function createHealthBarForZombie(zombie: Entity, maxHp: number, heightOf
     metallic: 0,
     roughness: 0.9
   })
-  HealthBarComponent.create(bar, { parent: zombie, maxHp, isPlayer: false, heightOffset })
+  HealthBarComponent.create(bar, { parent: zombie, maxHp, isPlayer: false, heightOffset, lastStyleVariant: -1 })
   return bar
 }
 
@@ -90,7 +91,8 @@ export function createHealthBarForPlayer(): Entity {
     parent: engine.PlayerEntity,
     maxHp: MAX_HP,
     isPlayer: true,
-    heightOffset: HEIGHT_PLAYER
+    heightOffset: HEIGHT_PLAYER,
+    lastStyleVariant: -1
   })
   return bar
 }
@@ -177,22 +179,27 @@ function healthBarSystem(dt: number) {
 
     let colors = getHealthColor(ratio)
     let emissiveIntensity = 0.25
+    let styleVariant = ratio > 0.6 ? 0 : ratio > 0.33 ? 1 : 2
     if (isPlayer && getGameTime() < getHealGlowEndTime()) {
       const glowPhase = (getGameTime() * 4) % (2 * Math.PI)
       const pulse = 0.5 + 0.5 * Math.sin(glowPhase)
       emissiveIntensity = 0.4 + pulse * 0.5
+      styleVariant = 3
       colors = {
         albedo: Color4.create(0.2, 1, 0.35, 0.95),
         emissive: Color3.create(0.2, 1, 0.3)
       }
     }
-    Material.setPbrMaterial(barEntity, {
-      albedoColor: colors.albedo,
-      emissiveColor: colors.emissive,
-      emissiveIntensity,
-      metallic: 0,
-      roughness: 0.9
-    })
+    if (barData.lastStyleVariant !== styleVariant || styleVariant === 3) {
+      Material.setPbrMaterial(barEntity, {
+        albedoColor: colors.albedo,
+        emissiveColor: colors.emissive,
+        emissiveIntensity,
+        metallic: 0,
+        roughness: 0.9
+      })
+      HealthBarComponent.getMutable(barEntity).lastStyleVariant = styleVariant
+    }
   }
 
   for (const e of toRemove) engine.removeEntity(e)

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -273,7 +273,6 @@ function recomputeZombiesAlive(runtime: ReturnType<typeof getMatchRuntimeMutable
   let alive = 0
   for (const [zombieId, spawnAtMs] of zombieSpawnAtById) {
     if (spawnAtMs > nowMs) continue
-    if (deadZombieIds.has(zombieId)) continue
     alive += 1
   }
   runtime.zombiesAlive = alive
@@ -912,9 +911,8 @@ export function setupLobbyServer(): void {
     const spawnAtMs = zombieSpawnAtById.get(data.zombieId)
     if (spawnAtMs === undefined) return
     if (spawnAtMs > getServerTime()) return
-    if (deadZombieIds.has(data.zombieId)) return
-
-    deadZombieIds.add(data.zombieId)
+    zombieSpawnAtById.delete(data.zombieId)
+    deadZombieIds.delete(data.zombieId)
     const runtime = getMatchRuntimeMutable()
     recomputeZombiesAlive(runtime, getServerTime())
     void room.send('zombieDied', { zombieId: data.zombieId })


### PR DESCRIPTION
Removed per-zombie bullet trigger listeners and moved bullet hit detection into the projectile update loop to reduce long-session multiplayer slowdown, especially on Windows.

Stopped health bars from rebuilding their material every frame, and cleaned dead zombies out of server-side tracking so match runtime data does not keep growing during long games.