### PR TITLE
Syncs zombie health across all players.

### DIFF
--- a/src/gun.ts
+++ b/src/gun.ts
@@ -47,7 +47,9 @@ const GUN_ROTATION_SMOOTH_SPEED = 12
 const ProjectileComponentSchema = {
   direction: Schemas.Vector3,
   startPosition: Schemas.Vector3,
-  canDamage: Schemas.Boolean
+  canDamage: Schemas.Boolean,
+  weaponType: Schemas.String,
+  shotSeq: Schemas.Number
 }
 export const ProjectileComponent = engine.defineComponent('ProjectileComponent', ProjectileComponentSchema)
 
@@ -90,7 +92,9 @@ function playGunAnimation() {
 function spawnProjectile(
   gunWorldPos: Vector3,
   gunWorldRot: { readonly x: number; readonly y: number; readonly z: number; readonly w: number },
-  canDamage: boolean = true
+  canDamage: boolean = true,
+  weaponType: 'gun' | 'shotgun' | 'minigun' = 'gun',
+  shotSeq: number = 0
 ): Vector3 {
   // Bullet direction = gun forward (where the barrel points), so bullet always matches gun aim
   const direction = Vector3.normalize(Vector3.rotate(Vector3.Forward(), gunWorldRot))
@@ -121,7 +125,9 @@ function spawnProjectile(
   ProjectileComponent.create(projectile, {
     direction,
     startPosition: Vector3.clone(spawnPos),
-    canDamage
+    canDamage,
+    weaponType,
+    shotSeq
   })
   return direction
 }
@@ -193,7 +199,7 @@ function projectileSystem(dt: number) {
       const distSq = dx * dx + dy * dy + dz * dz
       if (distSq > PROJECTILE_HIT_RADIUS_SQ) continue
 
-      damageZombie(zombie, 1)
+      damageZombie(zombie, 1, { weaponType: projData.weaponType as 'gun' | 'shotgun' | 'minigun', shotSeq: Math.floor(projData.shotSeq) })
       engine.removeEntity(projectile)
       break
     }
@@ -257,8 +263,9 @@ export function gunSystem(dt: number) {
 
   shootTimer = 0
   playGunAnimation()
-  const direction = spawnProjectile(gunWorldPos, gunWorldRot, true)
-  localShotSeq += 1
+  const nextShotSeq = localShotSeq + 1
+  const direction = spawnProjectile(gunWorldPos, gunWorldRot, true, 'gun', nextShotSeq)
+  localShotSeq = nextShotSeq
   sendPlayerShotRequest('gun', gunWorldPos, direction, localShotSeq)
 }
 
@@ -267,7 +274,7 @@ export function spawnReplicatedGunShotVisual(origin: Vector3, direction: Vector3
   const lenSq = directionXZ.x * directionXZ.x + directionXZ.z * directionXZ.z
   if (lenSq <= 0.0001) return
   const rotation = Quaternion.lookRotation(Vector3.normalize(directionXZ))
-  spawnProjectile(origin, rotation, false)
+  spawnProjectile(origin, rotation, false, 'gun', 0)
 }
 
 export function initGunSystems() {

--- a/src/miniGun.ts
+++ b/src/miniGun.ts
@@ -82,7 +82,9 @@ function playGunAnimation() {
 function spawnProjectile(
   gunWorldPos: Vector3,
   gunWorldRot: { readonly x: number; readonly y: number; readonly z: number; readonly w: number },
-  canDamage: boolean = true
+  canDamage: boolean = true,
+  weaponType: 'gun' | 'shotgun' | 'minigun' = 'minigun',
+  shotSeq: number = 0
 ): Vector3 {
   // Bullet direction = gun forward (where the barrel points), so bullet always matches gun aim
   const direction = Vector3.normalize(Vector3.rotate(Vector3.Forward(), gunWorldRot))
@@ -113,7 +115,9 @@ function spawnProjectile(
   ProjectileComponent.create(projectile, {
     direction,
     startPosition: Vector3.clone(spawnPos),
-    canDamage
+    canDamage,
+    weaponType,
+    shotSeq
   })
   if (canDamage) {
     // Bullets need a collider so they trigger zombie TriggerAreas
@@ -214,8 +218,9 @@ export function miniGunSystem(dt: number) {
 
   shootTimer = 0
   playGunAnimation()
-  const direction = spawnProjectile(gunWorldPos, gunWorldRot, true)
-  localShotSeq += 1
+  const nextShotSeq = localShotSeq + 1
+  const direction = spawnProjectile(gunWorldPos, gunWorldRot, true, 'minigun', nextShotSeq)
+  localShotSeq = nextShotSeq
   sendPlayerShotRequest('minigun', gunWorldPos, direction, localShotSeq)
 }
 
@@ -224,7 +229,7 @@ export function spawnReplicatedMiniGunShotVisual(origin: Vector3, direction: Vec
   const lenSq = directionXZ.x * directionXZ.x + directionXZ.z * directionXZ.z
   if (lenSq <= 0.0001) return
   const rotation = Quaternion.lookRotation(Vector3.normalize(directionXZ))
-  spawnProjectile(origin, rotation, false)
+  spawnProjectile(origin, rotation, false, 'minigun', 0)
 }
 
 export function initMiniGunSystems() {

--- a/src/multiplayer/matchWaveClient.ts
+++ b/src/multiplayer/matchWaveClient.ts
@@ -116,10 +116,15 @@ function plannedSpawnSystem(): void {
   }
 }
 
-function requestZombieHitToServer(zombieId: string, damage: number): void {
+function requestZombieHitToServer(
+  zombieId: string,
+  damage: number,
+  weaponType: 'gun' | 'shotgun' | 'minigun',
+  shotSeq: number
+): void {
   if (!zombieId) return
   if (!isLocalPlayerInCurrentMatch()) return
-  void room.send('zombieHitRequest', { zombieId, damage })
+  void room.send('zombieHitRequest', { zombieId, damage, weaponType, shotSeq })
 }
 
 export function initMatchWaveClientSystem(): void {

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -44,6 +44,11 @@ const SHOT_RATE_LIMIT_MS_BY_WEAPON: Record<ArenaWeaponType, number> = {
   shotgun: 450,
   minigun: 120
 }
+const ZOMBIE_HITS_ALLOWED_PER_SHOT: Record<ArenaWeaponType, number> = {
+  gun: 1,
+  shotgun: 3,
+  minigun: 1
+}
 const ZOMBIE_MAX_HP_BY_TYPE: Record<ZombieType, number> = {
   basic: 3,
   quick: 2,
@@ -105,6 +110,7 @@ const loadedProfileAddresses = new Set<string>()
 const awardedWaveGoldMilestones = new Set<number>()
 const playerCombatStateByAddress = new Map<string, PlayerCombatState>()
 const lastShotAtMsByPlayerAndWeapon = new Map<string, number>()
+const zombieHitAllowanceByShotKey = new Map<string, number>()
 const disconnectedLobbyPlayerSinceMs = new Map<string, number>()
 let disconnectedPlayerReconcileAccumulator = 0
 let isDisconnectReconcileInFlight = false
@@ -133,6 +139,10 @@ function isArenaWeaponType(value: string): value is ArenaWeaponType {
 
 function getZombieMaxHp(zombieType: ZombieType): number {
   return ZOMBIE_MAX_HP_BY_TYPE[zombieType]
+}
+
+function getShotAllowanceKey(address: string, weaponType: ArenaWeaponType, shotSeq: number): string {
+  return `${address.toLowerCase()}:${weaponType}:${Math.floor(shotSeq)}`
 }
 
 function getEquippedWeaponIds(address: string): LoadoutWeaponId[] {
@@ -246,6 +256,11 @@ function clearPlayerShotRateLimitState(address: string): void {
   const normalizedAddress = address.toLowerCase()
   for (const weaponType of Object.keys(SHOT_RATE_LIMIT_MS_BY_WEAPON) as ArenaWeaponType[]) {
     lastShotAtMsByPlayerAndWeapon.delete(`${normalizedAddress}:${weaponType}`)
+  }
+  for (const shotKey of zombieHitAllowanceByShotKey.keys()) {
+    if (shotKey.startsWith(`${normalizedAddress}:`)) {
+      zombieHitAllowanceByShotKey.delete(shotKey)
+    }
   }
 }
 
@@ -1034,19 +1049,28 @@ export function setupLobbyServer(): void {
   room.onMessage('zombieHitRequest', (data, context) => {
     if (!context) return
     const normalizedAddress = context.from.toLowerCase()
-    if (!isPlayerInArena(normalizedAddress)) return
+    if (!isPlayerInArena(context.from)) return
     const lobbyState = getLobbyState()
     if (lobbyState.phase !== LobbyPhase.MATCH_CREATED) return
     const runtime = getMatchRuntimeMutable()
     if (!runtime.isRunning) return
     if (!data.zombieId) return
+    if (!isArenaWeaponType(data.weaponType)) return
+
+    const shotSeq = Number.isFinite(data.shotSeq) ? Math.floor(data.shotSeq) : -1
+    if (shotSeq < 0) return
+
+    const allowanceKey = getShotAllowanceKey(normalizedAddress, data.weaponType, shotSeq)
+    const remainingHits = zombieHitAllowanceByShotKey.get(allowanceKey) ?? 0
+    if (remainingHits <= 0) return
+
     const spawnState = zombieSpawnAtById.get(data.zombieId)
     if (!spawnState) return
     const now = getServerTime()
     if (spawnState.spawnAtMs > now) return
 
-    const requestedDamage = Number.isFinite(data.damage) ? Math.floor(data.damage) : 1
-    const damage = Math.max(1, Math.min(10, requestedDamage))
+    const damage = 1
+    zombieHitAllowanceByShotKey.set(allowanceKey, remainingHits - 1)
     spawnState.hp = Math.max(0, spawnState.hp - damage)
 
     if (spawnState.hp > 0) {
@@ -1194,9 +1218,14 @@ export function setupLobbyServer(): void {
     const directionLen = Math.sqrt(directionLenSq)
 
     lastShotAtMsByPlayerAndWeapon.set(rateLimitKey, now)
+    const shotSeq = Number.isFinite(data.seq) ? Math.floor(data.seq) : 0
+    zombieHitAllowanceByShotKey.set(
+      getShotAllowanceKey(normalizedAddress, weaponType, shotSeq),
+      ZOMBIE_HITS_ALLOWED_PER_SHOT[weaponType]
+    )
     void room.send('playerShotBroadcast', {
       shooterAddress: normalizedAddress,
-      seq: Number.isFinite(data.seq) ? Math.floor(data.seq) : 0,
+      seq: shotSeq,
       weaponType,
       originX,
       originY,

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -30,7 +30,9 @@ const LobbyMessages = {
   }),
   zombieHitRequest: Schemas.Map({
     zombieId: Schemas.String,
-    damage: Schemas.Number
+    damage: Schemas.Number,
+    weaponType: Schemas.String,
+    shotSeq: Schemas.Number
   }),
   zombieHealthChanged: Schemas.Map({
     zombieId: Schemas.String,

--- a/src/shotGun.ts
+++ b/src/shotGun.ts
@@ -85,7 +85,9 @@ const SHOTGUN_SPREAD_TAN = Math.tan((SHOTGUN_SPREAD_DEG * Math.PI) / 180)
 function spawnProjectile(
   gunWorldPos: Vector3,
   gunWorldRot: { readonly x: number; readonly y: number; readonly z: number; readonly w: number },
-  canDamage: boolean = true
+  canDamage: boolean = true,
+  weaponType: 'gun' | 'shotgun' | 'minigun' = 'shotgun',
+  shotSeq: number = 0
 ): Vector3 {
   const baseDirection = Vector3.normalize(Vector3.rotate(Vector3.Forward(), gunWorldRot))
   const right = Vector3.normalize(Vector3.rotate(Vector3.Right(), gunWorldRot))
@@ -123,7 +125,9 @@ function spawnProjectile(
     ProjectileComponent.create(projectile, {
       direction,
       startPosition: Vector3.clone(spawnPos),
-      canDamage
+      canDamage,
+      weaponType,
+      shotSeq
     })
     if (canDamage) {
       MeshCollider.setSphere(projectile, ColliderLayer.CL_CUSTOM1)
@@ -224,8 +228,9 @@ export function shotGunSystem(dt: number) {
 
   shootTimer = 0
   playGunAnimation()
-  const direction = spawnProjectile(gunWorldPos, gunWorldRot, true)
-  localShotSeq += 1
+  const nextShotSeq = localShotSeq + 1
+  const direction = spawnProjectile(gunWorldPos, gunWorldRot, true, 'shotgun', nextShotSeq)
+  localShotSeq = nextShotSeq
   sendPlayerShotRequest('shotgun', gunWorldPos, direction, localShotSeq)
 }
 
@@ -234,7 +239,7 @@ export function spawnReplicatedShotGunShotVisual(origin: Vector3, direction: Vec
   const lenSq = directionXZ.x * directionXZ.x + directionXZ.z * directionXZ.z
   if (lenSq <= 0.0001) return
   const rotation = Quaternion.lookRotation(Vector3.normalize(directionXZ))
-  spawnProjectile(origin, rotation, false)
+  spawnProjectile(origin, rotation, false, 'shotgun', 0)
 }
 
 export function initShotGunSystems() {

--- a/src/zombie.ts
+++ b/src/zombie.ts
@@ -98,10 +98,14 @@ type SpawnZombieOptions = {
   networkId?: string
 }
 
-let reportServerZombieHit: ((zombieId: string, damage: number) => void) | null = null
+type ZombieHitWeaponType = 'gun' | 'shotgun' | 'minigun'
+
+let reportServerZombieHit: ((zombieId: string, damage: number, weaponType: ZombieHitWeaponType, shotSeq: number) => void) | null = null
 let zombieDeathSoundEntity: Entity | null = null
 let reportPlayerDamageToServer: ((amount: number) => void) | null = null
-export function setZombieHitReporter(reporter: ((zombieId: string, damage: number) => void) | null): void {
+export function setZombieHitReporter(
+  reporter: ((zombieId: string, damage: number, weaponType: ZombieHitWeaponType, shotSeq: number) => void) | null
+): void {
   reportServerZombieHit = reporter
 }
 export function setPlayerDamageReporter(reporter: ((amount: number) => void) | null): void {
@@ -436,11 +440,17 @@ export function applyZombieHealthUpdateByNetworkId(zombieId: string, hp: number)
 }
 
 /** Apply damage to a zombie. Networked zombies report hits to the server; local-only zombies resolve immediately. */
-export function damageZombie(entity: Entity, amount: number): boolean {
+export function damageZombie(
+  entity: Entity,
+  amount: number,
+  hitSource?: { weaponType: ZombieHitWeaponType; shotSeq: number }
+): boolean {
   if (!ZombieComponent.has(entity)) return false
   const zombie = ZombieComponent.get(entity)
   if (zombie.networkId) {
-    reportServerZombieHit?.(zombie.networkId, amount)
+    if (hitSource) {
+      reportServerZombieHit?.(zombie.networkId, amount, hitSource.weaponType, hitSource.shotSeq)
+    }
     return false
   }
 


### PR DESCRIPTION
Zombie HP is now tracked on the server instead of being resolved only locally. When a player hits a zombie, the server applies the damage, broadcasts the updated HP to every client, and confirms the kill only when HP reaches zero. This makes zombie health bars decrease consistently for everyone and ensures kill rewards are granted from the server-confirmed kill.

Closes #89 