### PR TITLE
ft: Hide pre-arena player visuals and sync remote weapon swaps

### DIFF
--- a/src/arenaRemoteDefaultWeapons.ts
+++ b/src/arenaRemoteDefaultWeapons.ts
@@ -1,8 +1,17 @@
 import { Animator, engine, Entity, GltfContainer, PlayerIdentityData, Transform } from '@dcl/sdk/ecs'
 import { Quaternion, Vector3 } from '@dcl/sdk/math'
-import { getLobbyState, getLocalAddress, getPlayerCombatSnapshot } from './multiplayer/lobbyClient'
+import {
+  getLobbyState,
+  getLocalAddress,
+  getPlayerArenaWeapon,
+  getPlayerCombatSnapshot,
+  isLocalReadyForMatch
+} from './multiplayer/lobbyClient'
+import { ArenaWeaponType } from './shared/loadoutCatalog'
 
 const DEFAULT_GUN_MODEL = 'assets/scene/Models/Gun01/Gun01.glb'
+const SHOTGUN_MODEL = 'assets/scene/Models/ShotGun01/ShotGun01.glb'
+const MINIGUN_MODEL = 'assets/scene/Models/MiniGun01/MiniGun01.glb'
 const REMOTE_GUN_OFFSET = Vector3.create(0, 0, 0)
 const REMOTE_GUN_ROTATION = Quaternion.Identity()
 const REMOTE_GUN_SCALE = Vector3.One()
@@ -10,6 +19,16 @@ const REMOTE_GUN_SCALE = Vector3.One()
 type RemoteWeaponEntry = {
   avatarEntity: Entity
   weaponRootEntity: Entity
+  weaponType: ArenaWeaponType
+}
+
+function canShowArenaRemoteWeapons(): boolean {
+  const lobbyState = getLobbyState()
+  const localAddress = getLocalAddress()
+  if (!lobbyState || !localAddress) return false
+  if (lobbyState.phase !== 'match_created') return false
+  if (!isLocalReadyForMatch()) return false
+  return lobbyState.arenaPlayers.some((player) => player.address.toLowerCase() === localAddress)
 }
 
 class ArenaRemoteDefaultWeapons {
@@ -25,6 +44,13 @@ class ArenaRemoteDefaultWeapons {
   private syncRoster(): void {
     const lobbyState = getLobbyState()
     const localAddress = getLocalAddress()
+    if (!canShowArenaRemoteWeapons()) {
+      for (const address of [...this.entriesByAddress.keys()]) {
+        this.removeEntry(address)
+      }
+      return
+    }
+
     const arenaAddresses = new Set((lobbyState?.arenaPlayers ?? []).map((player) => player.address.toLowerCase()))
     const visibleRemoteAddresses = new Set<string>()
 
@@ -33,6 +59,7 @@ class ArenaRemoteDefaultWeapons {
       if (!address || address === localAddress) continue
 
       const isDead = !!getPlayerCombatSnapshot(address)?.isDead
+      const weaponType = getPlayerArenaWeapon(address)
       if (!arenaAddresses.has(address) || isDead) {
         this.removeEntry(address)
         continue
@@ -43,12 +70,17 @@ class ArenaRemoteDefaultWeapons {
       const existing = this.entriesByAddress.get(address)
       if (existing) {
         existing.avatarEntity = avatarEntity
+        if (existing.weaponType !== weaponType) {
+          existing.weaponType = weaponType
+          applyRemoteWeaponModel(existing.weaponRootEntity, weaponType)
+        }
         continue
       }
 
       this.entriesByAddress.set(address, {
         avatarEntity,
-        weaponRootEntity: createRemoteDefaultWeapon()
+        weaponRootEntity: createRemoteDefaultWeapon(weaponType),
+        weaponType
       })
     }
 
@@ -81,7 +113,19 @@ class ArenaRemoteDefaultWeapons {
   }
 }
 
-function createRemoteDefaultWeapon(): Entity {
+function getRemoteWeaponModel(weaponType: ArenaWeaponType): string {
+  if (weaponType === 'shotgun') return SHOTGUN_MODEL
+  if (weaponType === 'minigun') return MINIGUN_MODEL
+  return DEFAULT_GUN_MODEL
+}
+
+function applyRemoteWeaponModel(weaponRootEntity: Entity, weaponType: ArenaWeaponType): void {
+  GltfContainer.createOrReplace(weaponRootEntity, {
+    src: getRemoteWeaponModel(weaponType)
+  })
+}
+
+function createRemoteDefaultWeapon(weaponType: ArenaWeaponType): Entity {
   const weaponRootEntity = engine.addEntity()
 
   Transform.create(weaponRootEntity, {
@@ -90,9 +134,7 @@ function createRemoteDefaultWeapon(): Entity {
     scale: REMOTE_GUN_SCALE
   })
 
-  GltfContainer.create(weaponRootEntity, {
-    src: DEFAULT_GUN_MODEL
-  })
+  applyRemoteWeaponModel(weaponRootEntity, weaponType)
   Animator.createOrReplace(weaponRootEntity)
   Animator.stopAllAnimations(weaponRootEntity)
 

--- a/src/healthBar.ts
+++ b/src/healthBar.ts
@@ -10,7 +10,7 @@ import {
 import { Vector3, Quaternion, Color4, Color3 } from '@dcl/sdk/math'
 import { ZombieComponent, getGameTime } from './zombie'
 import { getPlayerHp, MAX_HP, getHealGlowEndTime } from './playerHealth'
-import { getLocalAddress, getLobbyState, getPlayerCombatSnapshot } from './multiplayer/lobbyClient'
+import { getLocalAddress, getLobbyState, getPlayerCombatSnapshot, isLocalReadyForMatch } from './multiplayer/lobbyClient'
 
 const HealthBarSchema = {
   parent: Schemas.Entity,
@@ -36,6 +36,15 @@ const PLAYER_BAR_WIDTH = 1.2
 const PLAYER_BAR_HEIGHT = 0.2
 const PLAYER_BAR_DEPTH = 0.16
 const remotePlayerBarByAddress = new Map<string, Entity>()
+
+function canShowArenaPlayerBars(): boolean {
+  const localAddress = getLocalAddress()
+  const lobby = getLobbyState()
+  if (!localAddress || !lobby) return false
+  if (lobby.phase !== 'match_created') return false
+  if (!isLocalReadyForMatch()) return false
+  return lobby.arenaPlayers.some((player) => player.address.toLowerCase() === localAddress)
+}
 
 function removeRemotePlayerBar(address: string): void {
   const normalized = address.toLowerCase()
@@ -134,11 +143,7 @@ export function removeAllHealthBars(): void {
 function syncRemotePlayerHealthBars(): void {
   const localAddress = getLocalAddress()
   const lobby = getLobbyState()
-  const shouldShowTeammateBars =
-    !!localAddress &&
-    !!lobby &&
-    lobby.phase === 'match_created' &&
-    lobby.arenaPlayers.some((player) => player.address.toLowerCase() === localAddress)
+  const shouldShowTeammateBars = !!localAddress && !!lobby && canShowArenaPlayerBars()
 
   const expectedAddresses = new Set<string>()
   if (shouldShowTeammateBars) {

--- a/src/multiplayer/lobbyClient.ts
+++ b/src/multiplayer/lobbyClient.ts
@@ -8,6 +8,7 @@ import { applyAuthoritativeHealthState } from '../playerHealth'
 import { applyPlayerLoadoutSnapshot } from '../loadoutState'
 import { enableArenaWeapon, resetArenaWeaponProgress } from '../weaponManager'
 import { resetToIdle } from '../waveManager'
+import { ArenaWeaponType } from '../shared/loadoutCatalog'
 
 let latestLobbyEvent = ''
 let latestLobbyEventType = ''
@@ -16,6 +17,7 @@ let hasProfileLoadSent = false
 let localReadyForMatch = false
 let lastTeamWipeAffectedLocalPlayer = false
 const playerCombatStateByAddress = new Map<string, { hp: number; isDead: boolean; respawnAtMs: number; updatedAtMs: number }>()
+const playerArenaWeaponByAddress = new Map<string, ArenaWeaponType>()
 
 export function setupLobbyClient(): void {
   room.onMessage('lobbyEvent', (data) => {
@@ -33,6 +35,7 @@ export function setupLobbyClient(): void {
       lastTeamWipeAffectedLocalPlayer = false
     }
     if (data.type === 'team_wipe' || data.type === 'lobby') {
+      playerArenaWeaponByAddress.clear()
       resetToIdle()
       resetArenaWeaponProgress()
     }
@@ -59,6 +62,10 @@ export function setupLobbyClient(): void {
     const localAddress = getLocalAddress()
     if (!localAddress || data.address !== localAddress) return
     applyPlayerLoadoutSnapshot(data)
+  })
+  room.onMessage('playerArenaWeaponState', (data) => {
+    if (data.weaponType !== 'gun' && data.weaponType !== 'shotgun' && data.weaponType !== 'minigun') return
+    playerArenaWeaponByAddress.set(data.address.toLowerCase(), data.weaponType)
   })
   room.onMessage('matchAutoTeleport', (data) => {
     const localAddress = getLocalAddress()
@@ -153,6 +160,10 @@ export function sendPlayerShotRequest(
   })
 }
 
+export function sendPlayerArenaWeaponChanged(weaponType: ArenaWeaponType): void {
+  void room.send('playerArenaWeaponChanged', { weaponType })
+}
+
 export function getLocalAddress(): string {
   const identity = PlayerIdentityData.getOrNull(engine.PlayerEntity)
   return identity?.address?.toLowerCase() || ''
@@ -232,4 +243,8 @@ export function getPlayerCombatSnapshot(address: string): { hp: number; isDead: 
     isDead: state.isDead,
     respawnAtMs: state.respawnAtMs
   }
+}
+
+export function getPlayerArenaWeapon(address: string): ArenaWeaponType {
+  return playerArenaWeaponByAddress.get(address.toLowerCase()) ?? 'gun'
 }

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -112,6 +112,7 @@ const playerCombatStateByAddress = new Map<string, PlayerCombatState>()
 const lastShotAtMsByPlayerAndWeapon = new Map<string, number>()
 const zombieHitAllowanceByShotKey = new Map<string, number>()
 const disconnectedLobbyPlayerSinceMs = new Map<string, number>()
+const arenaWeaponByAddress = new Map<string, ArenaWeaponType>()
 let disconnectedPlayerReconcileAccumulator = 0
 let isDisconnectReconcileInFlight = false
 
@@ -166,6 +167,31 @@ function sendPlayerLoadoutState(address: string): void {
     ownedWeaponIds: getOwnedWeaponIds(normalizedAddress),
     equippedWeaponIds: getEquippedWeaponIds(normalizedAddress)
   })
+}
+
+function getPlayerArenaWeaponState(address: string): ArenaWeaponType {
+  return arenaWeaponByAddress.get(address.toLowerCase()) ?? 'gun'
+}
+
+function sendPlayerArenaWeaponState(address: string, to?: string[]): void {
+  const normalizedAddress = address.toLowerCase()
+  const payload = {
+    address: normalizedAddress,
+    weaponType: getPlayerArenaWeaponState(normalizedAddress)
+  }
+  if (to) {
+    void room.send('playerArenaWeaponState', payload, { to })
+    return
+  }
+  void room.send('playerArenaWeaponState', payload)
+}
+
+function sendArenaWeaponStatesTo(address: string): void {
+  const normalizedAddress = address.toLowerCase()
+  const lobbyState = getLobbyState()
+  for (const player of lobbyState.arenaPlayers) {
+    sendPlayerArenaWeaponState(player.address, [normalizedAddress])
+  }
 }
 
 function getPlayerDisplayName(address: string): string {
@@ -241,15 +267,19 @@ function getOrCreatePlayerCombatState(address: string): PlayerCombatState {
 
 function resetPlayerCombatState(address: string): void {
   const state = getOrCreatePlayerCombatState(address)
+  const normalizedAddress = address.toLowerCase()
   state.hp = PLAYER_MAX_HP
   state.isDead = false
   state.respawnAtMs = 0
   state.lastDamageRequestAtMs = 0
   state.lastHealRequestAtMs = 0
+  arenaWeaponByAddress.set(normalizedAddress, 'gun')
 }
 
 function removePlayerCombatState(address: string): void {
-  playerCombatStateByAddress.delete(address.toLowerCase())
+  const normalizedAddress = address.toLowerCase()
+  playerCombatStateByAddress.delete(normalizedAddress)
+  arenaWeaponByAddress.delete(normalizedAddress)
 }
 
 function clearPlayerShotRateLimitState(address: string): void {
@@ -380,6 +410,7 @@ function endMatchAndReturnToLobby(message: string): void {
   for (const player of players) {
     resetPlayerCombatState(player.address)
     sendPlayerHealthState(player.address)
+    sendPlayerArenaWeaponState(player.address)
   }
 
   sendLobbyReturnTeleport(players)
@@ -419,6 +450,7 @@ function resetMatchRuntime() {
   runtime.restDurationSeconds = WAVE_REST_SECONDS
   runtime.startedByAddress = ''
   clearZombieTracking(runtime)
+  arenaWeaponByAddress.clear()
 }
 
 function resetMatchToLobbyKeepingPlayers(): void {
@@ -824,6 +856,9 @@ function startZombieWaves(address: string, startReason: 'manual' | 'auto' = 'man
     resetPlayerCombatState(player.address)
   }
   sendPlayerHealthStatesForLobbyPlayers(state.arenaPlayers)
+  for (const player of state.arenaPlayers) {
+    sendPlayerArenaWeaponState(player.address)
+  }
 
   for (const player of state.arenaPlayers) {
     playerProgressStore.mutate(player.address, (progress) => {
@@ -933,6 +968,7 @@ export function setupLobbyServer(): void {
     if (!context) return
     await ensurePlayerLoadedAndInLobby(context.from)
     sendPlayerHealthState(context.from)
+    sendArenaWeaponStatesTo(context.from)
     if (isPlayerInArena(context.from)) {
       sendActivePotionsTo(context.from)
     }
@@ -1041,9 +1077,20 @@ export function setupLobbyServer(): void {
       createMatch(context.from)
     }
     sendPlayerHealthState(context.from)
+    sendArenaWeaponStatesTo(context.from)
     if (isPlayerInArena(context.from)) {
       sendActivePotionsTo(context.from)
     }
+  })
+
+  room.onMessage('playerArenaWeaponChanged', (data, context) => {
+    if (!context) return
+    const normalizedAddress = context.from.toLowerCase()
+    if (!isPlayerInArena(normalizedAddress)) return
+    if (!isArenaWeaponType(data.weaponType)) return
+
+    arenaWeaponByAddress.set(normalizedAddress, data.weaponType)
+    sendPlayerArenaWeaponState(normalizedAddress)
   })
 
   room.onMessage('zombieHitRequest', (data, context) => {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -81,6 +81,13 @@ const LobbyMessages = {
     directionZ: Schemas.Number,
     firedAtMs: Schemas.Int64
   }),
+  playerArenaWeaponChanged: Schemas.Map({
+    weaponType: Schemas.String
+  }),
+  playerArenaWeaponState: Schemas.Map({
+    address: Schemas.String,
+    weaponType: Schemas.String
+  }),
   playerShotBroadcast: Schemas.Map({
     shooterAddress: Schemas.String,
     seq: Schemas.Number,

--- a/src/weaponManager.ts
+++ b/src/weaponManager.ts
@@ -4,6 +4,7 @@ import { createShotGun, destroyShotGun } from './shotGun'
 import { createMiniGun, destroyMiniGun } from './miniGun'
 import { isPlayerDead } from './playerHealth'
 import { spendZombieCoins } from './zombieCoins'
+import { sendPlayerArenaWeaponChanged } from './multiplayer/lobbyClient'
 
 export type WeaponType = 'gun' | 'shotgun' | 'minigun'
 export const SHOTGUN_UNLOCK_COST_ZC = 50
@@ -67,6 +68,7 @@ function createWeapon(type: WeaponType): void {
   else if (type === 'shotgun') createShotGun()
   else if (type === 'minigun') createMiniGun()
   hasSpawnedWeapon = true
+  sendPlayerArenaWeaponChanged(type)
 }
 
 export function switchTo(type: WeaponType): boolean {


### PR DESCRIPTION
This PR cleans up pre-match presentation and improves multiplayer weapon visibility.

It hides player 3D health bars and remote weapon models during the lobby countdown, so they only appear once players are actually in the arena. It also adds network sync for active arena weapon changes, allowing other players to see weapon swaps in real time instead of always seeing the default gun.

Closes #96 
Closes #98 