### PR TITLE
ft: new speed pickup visual

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { getGameTime } from './zombie'
 import { rageEffectSystem } from './rageEffect'
 import { speedEffectSystem } from './speedEffect'
 import { initRageAura } from './rageAura'
+import { initSpeedAura } from './speedAura'
 import { initPotionSyncClient, potionPickupSystem, potionVisualSystem } from './potions'
 import { EntityNames } from '../assets/scene/entity-names'
 import { setupLobbyServer } from './server/lobbyServer'
@@ -227,6 +228,8 @@ export function main() {
   engine.addSystem(() => speedEffectSystem(getGameTime()))
   // Red aura around player when enraged
   initRageAura()
+  // Yellow speed aura + pickup flash around player
+  initSpeedAura()
   // Deferred brick placement (spawn from game loop, not from UI callback)
   initBrickSystem()
   // Health bar billboards above zombies

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -44,6 +44,9 @@ const RAGE_SHIELD_RADIUS = 1.6
 const RAGE_SHIELD_HIT_COOLDOWN_MS = 500
 const POTION_LIFETIME_MS = 20_000
 const POTION_PICKUP_RADIUS = 2.5
+const POTION_MIN_SEPARATION = 1.75
+const POTION_POSITION_SEARCH_ATTEMPTS = 16
+const POTION_POSITION_RING_STEP = 0.7
 const DISCONNECTED_PLAYER_GRACE_MS = 3000
 const DISCONNECTED_PLAYER_RECONCILE_INTERVAL_SECONDS = 0.5
 const SHOT_RATE_LIMIT_MS_BY_WEAPON: Record<ArenaWeaponType, number> = {
@@ -375,6 +378,57 @@ function clearActivePotions(notifyClients: boolean): void {
   }
 }
 
+function clampPotionCoordinate(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function isPotionPositionFree(
+  positionX: number,
+  positionZ: number,
+  occupiedPositions: Array<{ x: number; z: number }>
+): boolean {
+  for (const occupied of occupiedPositions) {
+    if (distanceXZ(positionX, positionZ, occupied.x, occupied.z) < POTION_MIN_SEPARATION) return false
+  }
+  return true
+}
+
+function getAvailablePotionPosition(
+  originX: number,
+  originY: number,
+  originZ: number,
+  occupiedPositions: Array<{ x: number; z: number }>
+): { positionX: number; positionY: number; positionZ: number } {
+  const allOccupiedPositions = [
+    ...occupiedPositions,
+    ...[...activePotionsById.values()].map((potion) => ({ x: potion.positionX, z: potion.positionZ }))
+  ]
+
+  if (isPotionPositionFree(originX, originZ, allOccupiedPositions)) {
+    return { positionX: originX, positionY: originY, positionZ: originZ }
+  }
+
+  const angleOffset = Math.random() * Math.PI * 2
+  for (let attempt = 0; attempt < POTION_POSITION_SEARCH_ATTEMPTS; attempt += 1) {
+    const ring = Math.floor(attempt / 4) + 1
+    const angle = angleOffset + attempt * ((Math.PI * 2) / 4)
+    const radius = POTION_POSITION_RING_STEP * ring
+    const candidateX = clampPotionCoordinate(originX + Math.cos(angle) * radius, SPAWN_MIN_X, SPAWN_MAX_X)
+    const candidateZ = clampPotionCoordinate(originZ + Math.sin(angle) * radius, SPAWN_MIN_Z, SPAWN_MAX_Z)
+    if (isPotionPositionFree(candidateX, candidateZ, allOccupiedPositions)) {
+      return { positionX: candidateX, positionY: originY, positionZ: candidateZ }
+    }
+  }
+
+  const fallbackAngle = angleOffset + Math.random() * Math.PI * 2
+  const fallbackRadius = POTION_POSITION_RING_STEP * (Math.floor(POTION_POSITION_SEARCH_ATTEMPTS / 4) + 1)
+  return {
+    positionX: clampPotionCoordinate(originX + Math.cos(fallbackAngle) * fallbackRadius, SPAWN_MIN_X, SPAWN_MAX_X),
+    positionY: originY,
+    positionZ: clampPotionCoordinate(originZ + Math.sin(fallbackAngle) * fallbackRadius, SPAWN_MIN_Z, SPAWN_MAX_Z)
+  }
+}
+
 function spawnPotionAt(positionX: number, positionY: number, positionZ: number, potionType: PotionType): void {
   nextPotionSequence += 1
   const potion: ActivePotionState = {
@@ -390,14 +444,22 @@ function spawnPotionAt(positionX: number, positionY: number, positionZ: number, 
 }
 
 function trySpawnPotionDrops(positionX: number, positionY: number, positionZ: number): void {
+  const occupiedPositions: Array<{ x: number; z: number }> = []
+
   if (Math.random() < HEALTH_POTION_DROP_CHANCE) {
-    spawnPotionAt(positionX, positionY, positionZ, 'health')
+    const spawn = getAvailablePotionPosition(positionX, positionY, positionZ, occupiedPositions)
+    spawnPotionAt(spawn.positionX, spawn.positionY, spawn.positionZ, 'health')
+    occupiedPositions.push({ x: spawn.positionX, z: spawn.positionZ })
   }
   if (Math.random() < RAGE_POTION_DROP_CHANCE) {
-    spawnPotionAt(positionX, positionY, positionZ, 'rage')
+    const spawn = getAvailablePotionPosition(positionX, positionY, positionZ, occupiedPositions)
+    spawnPotionAt(spawn.positionX, spawn.positionY, spawn.positionZ, 'rage')
+    occupiedPositions.push({ x: spawn.positionX, z: spawn.positionZ })
   }
   if (Math.random() < SPEED_POTION_DROP_CHANCE) {
-    spawnPotionAt(positionX, positionY, positionZ, 'speed')
+    const spawn = getAvailablePotionPosition(positionX, positionY, positionZ, occupiedPositions)
+    spawnPotionAt(spawn.positionX, spawn.positionY, spawn.positionZ, 'speed')
+    occupiedPositions.push({ x: spawn.positionX, z: spawn.positionZ })
   }
 }
 

--- a/src/speedAura.ts
+++ b/src/speedAura.ts
@@ -1,0 +1,92 @@
+import { engine, Entity, Material, MeshRenderer, Transform } from '@dcl/sdk/ecs'
+import { Color3, Color4, Quaternion, Vector3 } from '@dcl/sdk/math'
+import { getSpeedPickupFlashTimeLeft, isSpeedActive } from './speedEffect'
+import { getGameTime } from './zombie'
+
+const SPEED_FLASH_DURATION_SEC = 0.65
+const TORNADO_PARTICLE_COUNT = 8
+const TORNADO_BASE_HEIGHT = 0.3
+const TORNADO_HEIGHT_STEP = 0.23
+const TORNADO_BASE_RADIUS = 0.22
+const TORNADO_RADIUS_STEP = 0.075
+const TORNADO_ROTATION_SPEED = 7.5
+const TORNADO_VERTICAL_WAVE = 0.05
+const TORNADO_BASE_SCALE = 0.11
+const TORNADO_SCALE_STEP = 0.014
+const TORNADO_FLASH_SCALE_BONUS = 0.08
+
+const tornadoParticles: Entity[] = []
+
+function ensureParticle(index: number): Entity {
+  const existing = tornadoParticles[index]
+  if (existing !== undefined && Transform.has(existing)) return existing
+
+  const entity = engine.addEntity()
+  Transform.create(entity, {
+    parent: engine.PlayerEntity,
+    position: Vector3.Zero(),
+    rotation: Quaternion.Identity(),
+    scale: Vector3.Zero()
+  })
+  MeshRenderer.setSphere(entity)
+
+  const brightness = 0.78 + index * 0.025
+  Material.setPbrMaterial(entity, {
+    albedoColor: Color4.create(1, 0.9 + index * 0.01, 0.3, 0.9),
+    emissiveColor: Color3.create(1, brightness, 0.24),
+    emissiveIntensity: 1.6 + index * 0.08,
+    metallic: 0,
+    roughness: 0.35
+  })
+
+  tornadoParticles[index] = entity
+  return entity
+}
+
+function hideAllParticles(): void {
+  for (const entity of tornadoParticles) {
+    if (Transform.has(entity)) {
+      Transform.getMutable(entity).scale = Vector3.Zero()
+    }
+  }
+}
+
+export function speedAuraSystem(): void {
+  if (!Transform.has(engine.PlayerEntity)) return
+
+  const time = getGameTime()
+  const flashTimeLeft = getSpeedPickupFlashTimeLeft(time)
+  const flashRatio = Math.max(0, Math.min(1, flashTimeLeft / SPEED_FLASH_DURATION_SEC))
+  if (!isSpeedActive() && flashRatio <= 0) {
+    hideAllParticles()
+    return
+  }
+
+  for (let index = 0; index < TORNADO_PARTICLE_COUNT; index += 1) {
+    const particle = ensureParticle(index)
+    const phase = index / TORNADO_PARTICLE_COUNT
+    const angle = time * TORNADO_ROTATION_SPEED + phase * Math.PI * 2
+    const radius =
+      TORNADO_BASE_RADIUS +
+      index * TORNADO_RADIUS_STEP +
+      flashRatio * 0.06 +
+      0.03 * Math.sin(time * 9 + index * 0.8)
+    const height =
+      TORNADO_BASE_HEIGHT +
+      index * TORNADO_HEIGHT_STEP +
+      TORNADO_VERTICAL_WAVE * Math.sin(time * 10 + index * 0.7)
+    const scale = TORNADO_BASE_SCALE + index * TORNADO_SCALE_STEP + flashRatio * TORNADO_FLASH_SCALE_BONUS
+
+    const mutableTransform = Transform.getMutable(particle)
+    mutableTransform.position = Vector3.create(
+      Math.cos(angle) * radius,
+      height,
+      Math.sin(angle) * radius
+    )
+    mutableTransform.scale = Vector3.create(scale, scale, scale)
+  }
+}
+
+export function initSpeedAura(): void {
+  engine.addSystem(speedAuraSystem)
+}

--- a/src/speedEffect.ts
+++ b/src/speedEffect.ts
@@ -1,16 +1,22 @@
 export const SPEED_DURATION_SEC = 10
 const SPEED_FIRE_RATE_MULTIPLIER = 2
+const SPEED_PICKUP_FLASH_SEC = 0.65
 
 let speedEndTime = 0
+let speedPickupFlashEndTime = 0
 
 export function speedEffectSystem(gameTime: number): void {
   if (speedEndTime > 0 && gameTime >= speedEndTime) {
     speedEndTime = 0
   }
+  if (speedPickupFlashEndTime > 0 && gameTime >= speedPickupFlashEndTime) {
+    speedPickupFlashEndTime = 0
+  }
 }
 
 export function applySpeedEffect(gameTime: number): void {
   speedEndTime = gameTime + SPEED_DURATION_SEC
+  speedPickupFlashEndTime = gameTime + SPEED_PICKUP_FLASH_SEC
 }
 
 export function isSpeedActive(): boolean {
@@ -24,4 +30,9 @@ export function getSpeedTimeLeft(gameTime: number): number {
 
 export function getFireRateMultiplier(): number {
   return isSpeedActive() ? SPEED_FIRE_RATE_MULTIPLIER : 1
+}
+
+export function getSpeedPickupFlashTimeLeft(gameTime: number): number {
+  if (speedPickupFlashEndTime <= 0) return 0
+  return Math.max(0, speedPickupFlashEndTime - gameTime)
 }


### PR DESCRIPTION
Adds a new speed pickup visual effect and fixes overlapping pickup spawns.

Replaces the old shield-like speed aura with a yellow tornado of rotating particles plus a short pickup flash, and updates server-side pickup spawning so multiple drops always appear in distinct nearby positions instead of stacking on the same spot. 