### PR TITLE
ft: add hold to shoot to gun and shotgun

### DIFF
--- a/src/gun.ts
+++ b/src/gun.ts
@@ -4,7 +4,6 @@ import {
   Transform,
   inputSystem,
   InputAction,
-  PointerEventType,
   GltfContainer,
   Animator,
   MeshRenderer,
@@ -283,10 +282,10 @@ export function gunSystem(dt: number) {
   shootTimer += dt
   if (shootTimer < effectiveFireRate) return
 
-  const didShoot =
-    inputSystem.isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN) ||
-    inputSystem.isTriggered(InputAction.IA_PRIMARY, PointerEventType.PET_DOWN)
-  if (!didShoot) return
+  const isTriggerHeld =
+    inputSystem.isPressed(InputAction.IA_POINTER) ||
+    inputSystem.isPressed(InputAction.IA_PRIMARY)
+  if (!isTriggerHeld) return
 
   shootTimer = 0
   playGunAnimation()

--- a/src/shotGun.ts
+++ b/src/shotGun.ts
@@ -4,7 +4,6 @@ import {
   Transform,
   inputSystem,
   InputAction,
-  PointerEventType,
   GltfContainer,
   Animator,
   MeshRenderer,
@@ -227,10 +226,10 @@ export function shotGunSystem(dt: number) {
   shootTimer += dt
   if (shootTimer < effectiveFireRate) return
 
-  const didShoot =
-    inputSystem.isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN) ||
-    inputSystem.isTriggered(InputAction.IA_PRIMARY, PointerEventType.PET_DOWN)
-  if (!didShoot) return
+  const isTriggerHeld =
+    inputSystem.isPressed(InputAction.IA_POINTER) ||
+    inputSystem.isPressed(InputAction.IA_PRIMARY)
+  if (!isTriggerHeld) return
 
   shootTimer = 0
   playGunAnimation()


### PR DESCRIPTION
Enabled hold-to-fire for gun and shotgun while preserving their existing fire cadence.

These weapons now continue firing when the shoot button is held, but still respect the same per-shot cooldown as before, so they do not behave like full-auto weapons.

Closes #154