### PR TITLE
fix: mobile shooting getting stuck

### DIFF
--- a/src/gameplayInput.ts
+++ b/src/gameplayInput.ts
@@ -1,0 +1,31 @@
+import { inputSystem, InputAction } from '@dcl/sdk/ecs'
+
+let uiPointerCaptureActive = false
+
+function syncUiPointerCapture(): void {
+  if (
+    uiPointerCaptureActive &&
+    !inputSystem.isPressed(InputAction.IA_POINTER) &&
+    !inputSystem.isPressed(InputAction.IA_PRIMARY)
+  ) {
+    uiPointerCaptureActive = false
+  }
+}
+
+export function beginUiPointerCapture(): void {
+  uiPointerCaptureActive = true
+}
+
+export function endUiPointerCapture(): void {
+  uiPointerCaptureActive = false
+}
+
+export function isGameplayFireHeld(): boolean {
+  syncUiPointerCapture()
+  if (uiPointerCaptureActive) return false
+
+  return (
+    inputSystem.isPressed(InputAction.IA_POINTER) ||
+    inputSystem.isPressed(InputAction.IA_PRIMARY)
+  )
+}

--- a/src/gun.ts
+++ b/src/gun.ts
@@ -2,8 +2,6 @@ import {
   engine,
   Entity,
   Transform,
-  inputSystem,
-  InputAction,
   GltfContainer,
   Animator,
   MeshRenderer,
@@ -17,6 +15,7 @@ import { getLobbyState, getLocalAddress, isLocalReadyForMatch, sendPlayerShotReq
 import { getPlayerBulletColor } from './shared/playerColors'
 import { getFireRateMultiplier } from './speedEffect'
 import { getLocalRotationFromWorld } from './shared/weaponMath'
+import { isGameplayFireHeld } from './gameplayInput'
 import {
   WEAPON_DEFAULT_ROTATION,
   WEAPON_DEFAULT_SCALE,
@@ -282,9 +281,7 @@ export function gunSystem(dt: number) {
   shootTimer += dt
   if (shootTimer < effectiveFireRate) return
 
-  const isTriggerHeld =
-    inputSystem.isPressed(InputAction.IA_POINTER) ||
-    inputSystem.isPressed(InputAction.IA_PRIMARY)
+  const isTriggerHeld = isGameplayFireHeld()
   if (!isTriggerHeld) return
 
   shootTimer = 0

--- a/src/miniGun.ts
+++ b/src/miniGun.ts
@@ -2,8 +2,6 @@ import {
   engine,
   Entity,
   Transform,
-  inputSystem,
-  InputAction,
   GltfContainer,
   Animator,
   MeshRenderer,
@@ -19,6 +17,7 @@ import { getLobbyState, getLocalAddress, isLocalReadyForMatch, sendPlayerShotReq
 import { getPlayerBulletColor } from './shared/playerColors'
 import { getFireRateMultiplier } from './speedEffect'
 import { getLocalRotationFromWorld } from './shared/weaponMath'
+import { isGameplayFireHeld } from './gameplayInput'
 import {
   MINIGUN_HEAT_RECOVERY_SECONDS,
   MINIGUN_OVERHEAT_LOCK_SECONDS,
@@ -261,9 +260,7 @@ export function miniGunSystem(dt: number) {
 
   if (isOverheatLocked) return
 
-  const isTriggerHeld =
-    inputSystem.isPressed(InputAction.IA_POINTER) ||
-    inputSystem.isPressed(InputAction.IA_PRIMARY)
+  const isTriggerHeld = isGameplayFireHeld()
 
   if (isTriggerHeld) {
     minigunHeatRatio = Math.min(1, minigunHeatRatio + dt / MINIGUN_OVERHEAT_SECONDS)

--- a/src/shotGun.ts
+++ b/src/shotGun.ts
@@ -2,8 +2,6 @@ import {
   engine,
   Entity,
   Transform,
-  inputSystem,
-  InputAction,
   GltfContainer,
   Animator,
   MeshRenderer,
@@ -19,6 +17,7 @@ import { getLobbyState, getLocalAddress, isLocalReadyForMatch, sendPlayerShotReq
 import { getPlayerBulletColor } from './shared/playerColors'
 import { getFireRateMultiplier } from './speedEffect'
 import { getLocalRotationFromWorld } from './shared/weaponMath'
+import { isGameplayFireHeld } from './gameplayInput'
 import {
   WEAPON_DEFAULT_ROTATION,
   WEAPON_DEFAULT_SCALE,
@@ -226,9 +225,7 @@ export function shotGunSystem(dt: number) {
   shootTimer += dt
   if (shootTimer < effectiveFireRate) return
 
-  const isTriggerHeld =
-    inputSystem.isPressed(InputAction.IA_POINTER) ||
-    inputSystem.isPressed(InputAction.IA_PRIMARY)
+  const isTriggerHeld = isGameplayFireHeld()
   if (!isTriggerHeld) return
 
   shootTimer = 0

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -8,6 +8,7 @@ import { getGameTime } from './zombie'
 import { isSpeedActive, getSpeedTimeLeft, SPEED_DURATION_SEC } from './speedEffect'
 import { isRaging, getRageTimeLeft, RAGE_DURATION_SEC } from './rageEffect'
 import { getHealthPickupFeedback } from './potions'
+import { beginUiPointerCapture, endUiPointerCapture } from './gameplayInput'
 import {
   getCurrentWeapon,
   getWeaponUnlockCost,
@@ -502,12 +503,14 @@ export const uiMenu = () => {
               uvs: BACK_TO_LOBBY_BUTTON_UVS
             }}
             onMouseDown={() => {
+              beginUiPointerCapture()
               sendLeaveLobby()
               movePlayerTo({
                 newRelativePosition: LOBBY_RETURN_POSITION,
                 cameraTarget: LOBBY_RETURN_LOOK_TARGET
               })
             }}
+            onMouseUp={endUiPointerCapture}
           />
         </UiEntity>
       )}
@@ -849,6 +852,7 @@ export const uiMenu = () => {
                                 : { color: Color4.create(0.2, 0.75, 0.35, 1) }
                       }
                       onMouseDown={() => {
+                        beginUiPointerCapture()
                         if (weapon === 'brick') {
                           if (!canUse) return
                           if (brickTargetModeActive) {
@@ -866,6 +870,7 @@ export const uiMenu = () => {
                           switchTo(selectableWeapon)
                         }
                       }}
+                      onMouseUp={endUiPointerCapture}
                     >
                       {weaponCost > 0 && ((weapon === 'brick' && !canUse) || (weapon !== 'brick' && !isPurchased)) && (
                         <OutlinedText


### PR DESCRIPTION
## Summary

This fixes a mobile input issue where tapping the weapon selector or other HUD controls could start or keep weapon firing active as if auto-shoot was enabled.

## Root cause

`react-ecs` maps HUD `onMouseDown` events to `IA_POINTER`, and weapon firing was reading `inputSystem.isPressed(IA_POINTER / IA_PRIMARY)` directly.
On mobile, a UI tap could therefore be interpreted as gameplay fire input.

## Changes

- Added a shared gameplay input helper to separate fire input from UI pointer capture.
- Updated the HUD buttons to capture pointer input on `onMouseDown` and release it on `onMouseUp`.
- Updated `gun`, `shotgun`, and `minigun` to use the shared fire helper instead of reading raw `isPressed()` directly.

## Result

- Tapping the weapon selector on mobile no longer triggers or locks auto-fire.
- Hold-to-shoot behavior still works for actual gameplay input.

## Validation

- `npm run build`

Closes #117 