### PR TITLE
ft: Add "BUY" label to weapon selector

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -127,6 +127,8 @@ function isMobileRuntime(): boolean {
   return /android|iphone|ipad|ipod|mobile/i.test(userAgent)
 }
 
+const IS_MOBILE_RUNTIME = isMobileRuntime()
+
 function scaleUiValue(value: number, scale: number): number {
   return Math.max(1, Math.round(value * scale))
 }
@@ -196,7 +198,7 @@ export const uiMenu = () => {
     activeEffectBarCount > 0
       ? activeEffectBarCount * effectBarHeight + Math.max(0, activeEffectBarCount - 1) * effectBarGap + 4
       : 0
-  const weaponBarScale = isMobileRuntime() ? MOBILE_WEAPON_BAR_SCALE : 1
+  const weaponBarScale = IS_MOBILE_RUNTIME ? MOBILE_WEAPON_BAR_SCALE : 1
   const weaponBarBottomOffset = scaleUiValue(24, weaponBarScale)
   const weaponBarSidePadding = scaleUiValue(24, weaponBarScale)
   const weaponItemSideMargin = scaleUiValue(19, weaponBarScale)


### PR DESCRIPTION
UI: improve weapon bar purchase affordance and mobile readability

- Added an affordable purchase state to the weapon bar for shotgun, minigun, and brick.
- Shows BUY in yellow and highlights the price in the same color when the player can afford the item.
- Keeps the brick price visible while idle, then hides purchase text once brick target mode is active so the raised/selected state stays clean.
- Increased weapon bar item sizing by 10% on mobile only.
- Slightly increased weapon bar text sizes for better readability, including BUY, price labels, and the minigun overheat text.
- Restored gameplay prices to their original values after the temporary debug change.


Closes #163  