### PR TITLE
progressively-increase-bricks-price

### DIFF
--- a/src/brick.ts
+++ b/src/brick.ts
@@ -13,10 +13,26 @@ import { syncEntity } from '@dcl/sdk/network'
 import { Vector3, Quaternion, Color3, Color4 } from '@dcl/sdk/math'
 import { spendZombieCoins } from './zombieCoins'
 import { ARENA_BRICK_MAX_X, ARENA_BRICK_MAX_Z, ARENA_BRICK_MIN_X, ARENA_BRICK_MIN_Z } from './shared/arenaConfig'
+import {
+  BRICK_COST_BASE,
+  BRICK_COST_TIER_2, BRICK_COST_TIER_2_WAVE,
+  BRICK_COST_TIER_3, BRICK_COST_TIER_3_WAVE,
+  BRICK_COST_TIER_4, BRICK_COST_TIER_4_WAVE
+} from './shared/matchConfig'
+import { getCurrentWave } from './waveManager'
 
 const BRICK_GLB = 'assets/asset-packs/bricks_-_red/brick_red.glb'
 export const BRICK_HP = 5
-export const BRICK_COST_ZC = 20
+/** Base brick cost — use getBrickCost() for the wave-adjusted price. */
+export const BRICK_COST_ZC = BRICK_COST_BASE
+
+export function getBrickCost(): number {
+  const wave = getCurrentWave()
+  if (wave >= BRICK_COST_TIER_4_WAVE) return BRICK_COST_TIER_4
+  if (wave >= BRICK_COST_TIER_3_WAVE) return BRICK_COST_TIER_3
+  if (wave >= BRICK_COST_TIER_2_WAVE) return BRICK_COST_TIER_2
+  return BRICK_COST_BASE
+}
 
 // Obstacle radius for collision (brick footprint) – zombies cannot move inside this
 export const BRICK_RADIUS = 0.6
@@ -207,7 +223,7 @@ export function confirmBrickPlacementFromTargetMode(nowMs: number = Date.now()):
     cancelBrickTargetMode()
     return false
   }
-  if (!spendZombieCoins(BRICK_COST_ZC)) return false
+  if (!spendZombieCoins(getBrickCost())) return false
   pendingBrickPosition = placement
   cancelBrickTargetMode()
   return true
@@ -217,7 +233,7 @@ export function confirmBrickPlacementFromTargetMode(nowMs: number = Date.now()):
 export function tryPlaceBrick(): boolean {
   const placement = getPlacementPositionFromPlayer()
   if (!placement) return false
-  if (!spendZombieCoins(BRICK_COST_ZC)) return false
+  if (!spendZombieCoins(getBrickCost())) return false
   pendingBrickPosition = placement
   cancelBrickTargetMode()
   return true

--- a/src/shared/matchConfig.ts
+++ b/src/shared/matchConfig.ts
@@ -29,6 +29,15 @@ export const EXPLODER_ZOMBIE_MAX_SIMULTANEOUS_EARLY = 1
 export const EXPLODER_ZOMBIE_MAX_SIMULTANEOUS_LATE = 2
 export const EXPLODER_ZOMBIE_MAX_SIMULTANEOUS_LATE_WAVE = 10
 
+// Brick cost progression (price increases every N waves)
+export const BRICK_COST_BASE = 20
+export const BRICK_COST_TIER_2 = 35   // starts at wave 5
+export const BRICK_COST_TIER_3 = 55   // starts at wave 10
+export const BRICK_COST_TIER_4 = 80   // starts at wave 15
+export const BRICK_COST_TIER_2_WAVE = 5
+export const BRICK_COST_TIER_3_WAVE = 10
+export const BRICK_COST_TIER_4_WAVE = 15
+
 // Minigun overheat tuning
 export const MINIGUN_OVERHEAT_SECONDS = 6.5
 export const MINIGUN_OVERHEAT_LOCK_SECONDS = 3

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -25,7 +25,7 @@ import {
   isMiniGunOverheated
 } from './miniGun'
 import {
-  BRICK_COST_ZC,
+  getBrickCost,
   activateBrickTargetMode,
   confirmBrickPlacementFromTargetMode,
   isBrickTargetModeActive
@@ -856,14 +856,15 @@ export const uiMenu = () => {
             {(['gun', 'shotgun', 'minigun', 'brick'] as const).map((weapon: WeaponType | 'brick') => {
                 const selectableWeapon = weapon === 'brick' ? null : weapon
                 const isPurchasableWeapon = weapon === 'shotgun' || weapon === 'minigun'
-                const weaponCost = weapon === 'brick' ? BRICK_COST_ZC : isPurchasableWeapon ? getWeaponUnlockCost(weapon) : 0
+                const brickCost = getBrickCost()
+                const weaponCost = weapon === 'brick' ? brickCost : isPurchasableWeapon ? getWeaponUnlockCost(weapon) : 0
                 const isPurchased = selectableWeapon === null ? true : selectableWeapon === 'gun' ? true : isWeaponPurchasedInMatch(selectableWeapon)
                 const canAfford = weaponCost <= 0 || getZombieCoins() >= weaponCost
                 const canUse =
                   weapon === 'gun' ||
                   (weapon === 'shotgun' && isShotgunUnlocked()) ||
                   (weapon === 'minigun' && isMinigunUnlocked()) ||
-                  (weapon === 'brick' && getZombieCoins() >= BRICK_COST_ZC)
+                  (weapon === 'brick' && getZombieCoins() >= brickCost)
                 const isLockedVisual =
                   weapon === 'gun'
                     ? false
@@ -871,7 +872,7 @@ export const uiMenu = () => {
                       ? !isPurchased
                     : weapon === 'minigun'
                         ? !isPurchased
-                        : getZombieCoins() < BRICK_COST_ZC
+                        : getZombieCoins() < brickCost
                 const isSelected = weapon === 'brick' ? brickTargetModeActive : currentWeapon === selectableWeapon
                 const showBuyPrompt =
                   (isPurchasableWeapon && !isPurchased && canAfford) ||


### PR DESCRIPTION
matchConfig.ts — added price tier constants and wave thresholds
brick.ts — added getBrickCost() which reads the current wave and returns the appropriate price; both purchase functions now use it
ui.tsx — brick button displays the dynamic cost, affordability check and lock visual all reflect the current wave price
Closes #115 