### PR TITLE
feat: show correct tier model per equipped loadout weapon in arena

### DIFF
--- a/src/arenaRemoteDefaultWeapons.ts
+++ b/src/arenaRemoteDefaultWeapons.ts
@@ -7,7 +7,7 @@ import {
   getPlayerCombatSnapshot,
   isLocalReadyForMatch
 } from './multiplayer/lobbyClient'
-import { ArenaWeaponType } from './shared/loadoutCatalog'
+import { ArenaWeaponType, getArenaWeaponModelPath } from './shared/loadoutCatalog'
 import {
   WEAPON_DEFAULT_ROTATION,
   WEAPON_DEFAULT_SCALE,
@@ -15,9 +15,6 @@ import {
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
 
-const DEFAULT_GUN_MODEL = 'assets/scene/Models/drones/gun/DroneGun.glb'
-const SHOTGUN_MODEL = 'assets/scene/Models/drones/shotgun/DroneShotGun.glb'
-const MINIGUN_MODEL = 'assets/scene/Models/drones/minigun/DroneMinigun.glb'
 const GUN_SHOOT_ANIM = 'DroneGunShoot'
 const SHOTGUN_SHOOT_ANIM = 'DroneShotGunShoot'
 const MINIGUN_SHOOT_ANIM = 'DroneMinigunShoot'
@@ -27,6 +24,7 @@ type RemoteWeaponEntry = {
   weaponRootEntity: Entity
   weaponModelEntity: Entity
   weaponType: ArenaWeaponType
+  upgradeLevel: number
 }
 
 function canShowArenaRemoteWeapons(): boolean {
@@ -66,7 +64,7 @@ class ArenaRemoteDefaultWeapons {
       if (!address || address === localAddress) continue
 
       const isDead = !!getPlayerCombatSnapshot(address)?.isDead
-      const weaponType = getPlayerArenaWeapon(address)
+      const { weaponType, upgradeLevel } = getPlayerArenaWeapon(address)
       if (!arenaAddresses.has(address) || isDead) {
         this.removeEntry(address)
         continue
@@ -77,17 +75,19 @@ class ArenaRemoteDefaultWeapons {
       const existing = this.entriesByAddress.get(address)
       if (existing) {
         existing.avatarEntity = avatarEntity
-        if (existing.weaponType !== weaponType) {
+        if (existing.weaponType !== weaponType || existing.upgradeLevel !== upgradeLevel) {
           existing.weaponType = weaponType
-          applyRemoteWeaponModel(existing.weaponModelEntity, weaponType)
+          existing.upgradeLevel = upgradeLevel
+          applyRemoteWeaponModel(existing.weaponModelEntity, weaponType, upgradeLevel)
         }
         continue
       }
 
       this.entriesByAddress.set(address, {
         avatarEntity,
-        ...createRemoteDefaultWeapon(weaponType),
-        weaponType
+        ...createRemoteDefaultWeapon(weaponType, upgradeLevel),
+        weaponType,
+        upgradeLevel
       })
     }
 
@@ -142,21 +142,15 @@ class ArenaRemoteDefaultWeapons {
 
 let arenaRemoteDefaultWeapons: ArenaRemoteDefaultWeapons | null = null
 
-function getRemoteWeaponModel(weaponType: ArenaWeaponType): string {
-  if (weaponType === 'shotgun') return SHOTGUN_MODEL
-  if (weaponType === 'minigun') return MINIGUN_MODEL
-  return DEFAULT_GUN_MODEL
-}
-
 function getRemoteWeaponShootClip(weaponType: ArenaWeaponType): string {
   if (weaponType === 'shotgun') return SHOTGUN_SHOOT_ANIM
   if (weaponType === 'minigun') return MINIGUN_SHOOT_ANIM
   return GUN_SHOOT_ANIM
 }
 
-function applyRemoteWeaponModel(weaponModelEntity: Entity, weaponType: ArenaWeaponType): void {
+function applyRemoteWeaponModel(weaponModelEntity: Entity, weaponType: ArenaWeaponType, upgradeLevel: number): void {
   GltfContainer.createOrReplace(weaponModelEntity, {
-    src: getRemoteWeaponModel(weaponType)
+    src: getArenaWeaponModelPath(weaponType, upgradeLevel)
   })
 
   Animator.createOrReplace(weaponModelEntity, {
@@ -164,7 +158,7 @@ function applyRemoteWeaponModel(weaponModelEntity: Entity, weaponType: ArenaWeap
   })
 }
 
-function createRemoteDefaultWeapon(weaponType: ArenaWeaponType): {
+function createRemoteDefaultWeapon(weaponType: ArenaWeaponType, upgradeLevel: number): {
   weaponRootEntity: Entity
   weaponModelEntity: Entity
 } {
@@ -184,7 +178,7 @@ function createRemoteDefaultWeapon(weaponType: ArenaWeaponType): {
     scale: WEAPON_DEFAULT_SCALE
   })
 
-  applyRemoteWeaponModel(weaponModelEntity, weaponType)
+  applyRemoteWeaponModel(weaponModelEntity, weaponType, upgradeLevel)
   return { weaponRootEntity, weaponModelEntity }
 }
 

--- a/src/gun.ts
+++ b/src/gun.ts
@@ -23,7 +23,8 @@ import {
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
 
-const GUN_MODEL = 'assets/scene/Models/drones/gun/DroneGun.glb'
+import { getArenaWeaponModelPath } from './shared/loadoutCatalog'
+
 const DEBUG_SHOW_GUN_IN_LOBBY = false
 
 const GUN_SHOOT_ANIM = 'DroneGunShoot'
@@ -144,7 +145,7 @@ function spawnProjectile(
   return direction
 }
 
-export function createGun(): Entity {
+export function createGun(upgradeLevel: number = 1): Entity {
   if (gunEntity !== null) return gunEntity
 
   const gun = engine.addEntity()
@@ -164,7 +165,7 @@ export function createGun(): Entity {
   })
 
   GltfContainer.create(gunModel, {
-    src: GUN_MODEL
+    src: getArenaWeaponModelPath('gun', upgradeLevel)
   })
 
   Animator.create(gunModel, {

--- a/src/miniGun.ts
+++ b/src/miniGun.ts
@@ -30,7 +30,7 @@ import {
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
 
-const GUN_MODEL = 'assets/scene/Models/drones/minigun/DroneMinigun.glb'
+import { getArenaWeaponModelPath } from './shared/loadoutCatalog'
 
 const GUN_SHOOT_ANIM = 'DroneMinigunShoot'
 
@@ -166,7 +166,7 @@ function spawnProjectile(
   return direction
 }
 
-export function createMiniGun(): Entity {
+export function createMiniGun(upgradeLevel: number = 1): Entity {
   if (gunEntity !== null) return gunEntity
 
   const gun = engine.addEntity()
@@ -186,7 +186,7 @@ export function createMiniGun(): Entity {
   })
 
   GltfContainer.create(gunModel, {
-    src: GUN_MODEL
+    src: getArenaWeaponModelPath('minigun', upgradeLevel)
   })
 
   Animator.create(gunModel, {

--- a/src/multiplayer/lobbyClient.ts
+++ b/src/multiplayer/lobbyClient.ts
@@ -19,7 +19,7 @@ let localReadyForMatch = false
 let lastTeamWipeAffectedLocalPlayer = false
 const GAME_OVER_OVERLAY_DELAY_MS = 2000
 const playerCombatStateByAddress = new Map<string, { hp: number; isDead: boolean; respawnAtMs: number; updatedAtMs: number }>()
-const playerArenaWeaponByAddress = new Map<string, ArenaWeaponType>()
+const playerArenaWeaponByAddress = new Map<string, { weaponType: ArenaWeaponType; upgradeLevel: number }>()
 const playerPowerupStateByAddress = new Map<string, { rageShieldEndAtMs: number; speedEndAtMs: number }>()
 
 function resetLocalMatchUiState(): void {
@@ -82,7 +82,8 @@ export function setupLobbyClient(): void {
   })
   room.onMessage('playerArenaWeaponState', (data) => {
     if (data.weaponType !== 'gun' && data.weaponType !== 'shotgun' && data.weaponType !== 'minigun') return
-    playerArenaWeaponByAddress.set(data.address.toLowerCase(), data.weaponType)
+    const upgradeLevel = typeof data.upgradeLevel === 'number' && data.upgradeLevel >= 1 ? data.upgradeLevel : 1
+    playerArenaWeaponByAddress.set(data.address.toLowerCase(), { weaponType: data.weaponType, upgradeLevel })
   })
   room.onMessage('playerPowerupState', (data) => {
     playerPowerupStateByAddress.set(data.address.toLowerCase(), {
@@ -198,8 +199,8 @@ export function sendPlayerExplosionDamageRequest(zombieId: string, amount: numbe
   void room.send('playerExplosionDamageRequest', { zombieId, amount })
 }
 
-export function sendPlayerArenaWeaponChanged(weaponType: ArenaWeaponType): void {
-  void room.send('playerArenaWeaponChanged', { weaponType })
+export function sendPlayerArenaWeaponChanged(weaponType: ArenaWeaponType, upgradeLevel: number): void {
+  void room.send('playerArenaWeaponChanged', { weaponType, upgradeLevel })
 }
 
 export function getLocalAddress(): string {
@@ -289,8 +290,8 @@ export function getPlayerCombatSnapshot(address: string): { hp: number; isDead: 
   }
 }
 
-export function getPlayerArenaWeapon(address: string): ArenaWeaponType {
-  return playerArenaWeaponByAddress.get(address.toLowerCase()) ?? 'gun'
+export function getPlayerArenaWeapon(address: string): { weaponType: ArenaWeaponType; upgradeLevel: number } {
+  return playerArenaWeaponByAddress.get(address.toLowerCase()) ?? { weaponType: 'gun', upgradeLevel: 1 }
 }
 
 export function getPlayerPowerupSnapshot(address: string): { rageShieldEndAtMs: number; speedEndAtMs: number } {

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -151,7 +151,7 @@ const zombieHitAllowanceByShotKey = new Map<string, number>()
 const lastRageShieldHitAtMsByPlayerAndZombie = new Map<string, number>()
 const explosiveZombieDamageByPlayerKey = new Set<string>()
 const disconnectedLobbyPlayerSinceMs = new Map<string, number>()
-const arenaWeaponByAddress = new Map<string, ArenaWeaponType>()
+const arenaWeaponByAddress = new Map<string, { weaponType: ArenaWeaponType; upgradeLevel: number }>()
 let disconnectedPlayerReconcileAccumulator = 0
 let isDisconnectReconcileInFlight = false
 let pendingTeamWipeReturn: PendingTeamWipeReturn | null = null
@@ -226,15 +226,17 @@ function sendPlayerLoadoutState(address: string): void {
   })
 }
 
-function getPlayerArenaWeaponState(address: string): ArenaWeaponType {
-  return arenaWeaponByAddress.get(address.toLowerCase()) ?? 'gun'
+function getPlayerArenaWeaponState(address: string): { weaponType: ArenaWeaponType; upgradeLevel: number } {
+  return arenaWeaponByAddress.get(address.toLowerCase()) ?? { weaponType: 'gun', upgradeLevel: 1 }
 }
 
 function sendPlayerArenaWeaponState(address: string, to?: string[]): void {
   const normalizedAddress = address.toLowerCase()
+  const state = getPlayerArenaWeaponState(normalizedAddress)
   const payload = {
     address: normalizedAddress,
-    weaponType: getPlayerArenaWeaponState(normalizedAddress)
+    weaponType: state.weaponType,
+    upgradeLevel: state.upgradeLevel
   }
   if (to) {
     void room.send('playerArenaWeaponState', payload, { to })
@@ -360,7 +362,7 @@ function resetPlayerCombatState(address: string): void {
   state.lastHealRequestAtMs = 0
   state.rageShieldEndAtMs = 0
   state.speedEndAtMs = 0
-  arenaWeaponByAddress.set(normalizedAddress, 'gun')
+  arenaWeaponByAddress.set(normalizedAddress, { weaponType: 'gun', upgradeLevel: 1 })
   sendPlayerPowerupState(normalizedAddress)
 }
 
@@ -1382,7 +1384,11 @@ export function setupLobbyServer(): void {
     if (!isPlayerInArena(normalizedAddress)) return
     if (!isArenaWeaponType(data.weaponType)) return
 
-    arenaWeaponByAddress.set(normalizedAddress, data.weaponType)
+    const upgradeLevel =
+      Number.isInteger(data.upgradeLevel) && data.upgradeLevel >= 1 && data.upgradeLevel <= 3
+        ? data.upgradeLevel
+        : 1
+    arenaWeaponByAddress.set(normalizedAddress, { weaponType: data.weaponType, upgradeLevel })
     sendPlayerArenaWeaponState(normalizedAddress)
   })
 

--- a/src/shared/loadoutCatalog.ts
+++ b/src/shared/loadoutCatalog.ts
@@ -108,3 +108,23 @@ export function getLoadoutWeaponDefinition(weaponId: string): LoadoutWeaponDefin
 export function getWeaponUpgrades(weaponType: ArenaWeaponType): LoadoutWeaponDefinition[] {
   return LOADOUT_WEAPON_DEFINITIONS.filter((w) => w.arenaWeaponType === weaponType)
 }
+
+export function getArenaWeaponModelPath(weaponType: ArenaWeaponType, upgradeLevel: number): string {
+  const level = Math.max(1, Math.min(3, upgradeLevel))
+  if (weaponType === 'gun') {
+    if (level === 3) return 'assets/scene/Models/drones/gun/DroneGunGold.glb'
+    if (level === 2) return 'assets/scene/Models/drones/gun/DroneGunUp1.glb'
+    return 'assets/scene/Models/drones/gun/DroneGun.glb'
+  }
+  if (weaponType === 'shotgun') {
+    if (level === 3) return 'assets/scene/Models/drones/shotgun/DroneShotGunGold.glb'
+    if (level === 2) return 'assets/scene/Models/drones/shotgun/DroneShotGunUp1.glb'
+    return 'assets/scene/Models/drones/shotgun/DroneShotGun.glb'
+  }
+  if (weaponType === 'minigun') {
+    if (level === 3) return 'assets/scene/Models/drones/minigun/DroneMinigunGold.glb'
+    if (level === 2) return 'assets/scene/Models/drones/minigun/DroneMinigunUp1.glb'
+    return 'assets/scene/Models/drones/minigun/DroneMinigun.glb'
+  }
+  return 'assets/scene/Models/drones/gun/DroneGun.glb'
+}

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -95,11 +95,13 @@ const LobbyMessages = {
     firedAtMs: Schemas.Int64
   }),
   playerArenaWeaponChanged: Schemas.Map({
-    weaponType: Schemas.String
+    weaponType: Schemas.String,
+    upgradeLevel: Schemas.Number
   }),
   playerArenaWeaponState: Schemas.Map({
     address: Schemas.String,
-    weaponType: Schemas.String
+    weaponType: Schemas.String,
+    upgradeLevel: Schemas.Number
   }),
   playerPowerupState: Schemas.Map({
     address: Schemas.String,

--- a/src/shotGun.ts
+++ b/src/shotGun.ts
@@ -25,7 +25,7 @@ import {
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
 
-const GUN_MODEL = 'assets/scene/Models/drones/shotgun/DroneShotGun.glb'
+import { getArenaWeaponModelPath } from './shared/loadoutCatalog'
 
 const GUN_SHOOT_ANIM = 'DroneShotGunShoot'
 
@@ -136,7 +136,7 @@ function spawnProjectile(
   return baseDirection
 }
 
-export function createShotGun(): Entity {
+export function createShotGun(upgradeLevel: number = 1): Entity {
   if (gunEntity !== null) return gunEntity
 
   const gun = engine.addEntity()
@@ -156,7 +156,7 @@ export function createShotGun(): Entity {
   })
 
   GltfContainer.create(gunModel, {
-    src: GUN_MODEL
+    src: getArenaWeaponModelPath('shotgun', upgradeLevel)
   })
 
   Animator.create(gunModel, {

--- a/src/weaponManager.ts
+++ b/src/weaponManager.ts
@@ -5,6 +5,8 @@ import { createMiniGun, destroyMiniGun, resetMiniGunOverheatState } from './mini
 import { isPlayerDead } from './playerHealth'
 import { spendZombieCoins } from './zombieCoins'
 import { sendPlayerArenaWeaponChanged } from './multiplayer/lobbyClient'
+import { getPlayerLoadoutSnapshot } from './loadoutState'
+import { getLoadoutWeaponDefinition } from './shared/loadoutCatalog'
 
 export type WeaponType = 'gun' | 'shotgun' | 'minigun'
 export const SHOTGUN_UNLOCK_COST_ZC = 300
@@ -55,6 +57,15 @@ export function purchaseWeapon(type: WeaponType): boolean {
   return true
 }
 
+function getEquippedUpgradeLevel(type: WeaponType): number {
+  const snapshot = getPlayerLoadoutSnapshot()
+  for (const weaponId of snapshot.equippedWeaponIds) {
+    const def = getLoadoutWeaponDefinition(weaponId)
+    if (def?.arenaWeaponType === type) return def.upgradeLevel
+  }
+  return 1
+}
+
 function destroyCurrentWeapon(): void {
   if (!hasSpawnedWeapon) return
   if (currentWeapon === 'gun') destroyGun()
@@ -64,11 +75,12 @@ function destroyCurrentWeapon(): void {
 }
 
 function createWeapon(type: WeaponType): void {
-  if (type === 'gun') createGun()
-  else if (type === 'shotgun') createShotGun()
-  else if (type === 'minigun') createMiniGun()
+  const upgradeLevel = getEquippedUpgradeLevel(type)
+  if (type === 'gun') createGun(upgradeLevel)
+  else if (type === 'shotgun') createShotGun(upgradeLevel)
+  else if (type === 'minigun') createMiniGun(upgradeLevel)
   hasSpawnedWeapon = true
-  sendPlayerArenaWeaponChanged(type)
+  sendPlayerArenaWeaponChanged(type, upgradeLevel)
 }
 
 export function switchTo(type: WeaponType): boolean {


### PR DESCRIPTION
Players who equip gun_t2/t3, shotgun_t2/t3, or minigun_t2/t3 in the lobby shop now see the matching drone model (Up1 / Gold variants) on their own client and on all remote clients. Adds upgradeLevel to playerArenaWeaponChanged and playerArenaWeaponState messages so the correct GLB is selected across the full multiplayer chain (server → broadcast → remote render).