### PR TITLE
Fix loadout upgrade persistence and simplify lobby shop UI

### DIFF
--- a/src/arenaRemoteDefaultWeapons.ts
+++ b/src/arenaRemoteDefaultWeapons.ts
@@ -7,17 +7,13 @@ import {
   getPlayerCombatSnapshot,
   isLocalReadyForMatch
 } from './multiplayer/lobbyClient'
-import { ArenaWeaponType, getArenaWeaponModelPath } from './shared/loadoutCatalog'
+import { ArenaWeaponType, getArenaWeaponModelPath, getArenaWeaponShootClip } from './shared/loadoutCatalog'
 import {
   WEAPON_DEFAULT_ROTATION,
   WEAPON_DEFAULT_SCALE,
   WEAPON_MODEL_VISUAL_OFFSET,
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
-
-const GUN_SHOOT_ANIM = 'DroneGunShoot'
-const SHOTGUN_SHOOT_ANIM = 'DroneShotGunShoot'
-const MINIGUN_SHOOT_ANIM = 'DroneMinigunShoot'
 
 type RemoteWeaponEntry = {
   avatarEntity: Entity
@@ -126,7 +122,7 @@ class ArenaRemoteDefaultWeapons {
     if (!Animator.has(entry.weaponModelEntity)) return
 
     const animator = Animator.getMutable(entry.weaponModelEntity)
-    const clip = getRemoteWeaponShootClip(weaponType)
+    const clip = getRemoteWeaponShootClip(weaponType, entry.upgradeLevel)
     const shootState = animator.states.find((state) => state.clip === clip)
     if (!shootState) return
 
@@ -142,10 +138,8 @@ class ArenaRemoteDefaultWeapons {
 
 let arenaRemoteDefaultWeapons: ArenaRemoteDefaultWeapons | null = null
 
-function getRemoteWeaponShootClip(weaponType: ArenaWeaponType): string {
-  if (weaponType === 'shotgun') return SHOTGUN_SHOOT_ANIM
-  if (weaponType === 'minigun') return MINIGUN_SHOOT_ANIM
-  return GUN_SHOOT_ANIM
+function getRemoteWeaponShootClip(weaponType: ArenaWeaponType, upgradeLevel: number): string {
+  return getArenaWeaponShootClip(weaponType, upgradeLevel)
 }
 
 function applyRemoteWeaponModel(weaponModelEntity: Entity, weaponType: ArenaWeaponType, upgradeLevel: number): void {
@@ -154,7 +148,7 @@ function applyRemoteWeaponModel(weaponModelEntity: Entity, weaponType: ArenaWeap
   })
 
   Animator.createOrReplace(weaponModelEntity, {
-    states: [{ clip: getRemoteWeaponShootClip(weaponType), playing: false, loop: false, speed: 1 }]
+    states: [{ clip: getRemoteWeaponShootClip(weaponType, upgradeLevel), playing: false, loop: false, speed: 1 }]
   })
 }
 

--- a/src/gun.ts
+++ b/src/gun.ts
@@ -23,11 +23,9 @@ import {
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
 
-import { getArenaWeaponModelPath } from './shared/loadoutCatalog'
+import { getArenaWeaponModelPath, getArenaWeaponShootClip } from './shared/loadoutCatalog'
 
 const DEBUG_SHOW_GUN_IN_LOBBY = false
-
-const GUN_SHOOT_ANIM = 'DroneGunShoot'
 
 // Gun config - tweak these to your liking
 const ROUNDS_PER_SECOND = 2 // Manual fire rate: 1 shot every 0.5s
@@ -99,10 +97,10 @@ function getNearestZombie(fromPosition: Vector3): Entity | null {
 function playGunAnimation() {
   if (gunModelEntity && Animator.has(gunModelEntity)) {
     const animator = Animator.getMutable(gunModelEntity)
-    const shootState = animator.states.find((s) => s.clip === GUN_SHOOT_ANIM)
+    const shootState = animator.states[0]
     if (shootState) {
       for (const s of animator.states) {
-        s.playing = s.clip === GUN_SHOOT_ANIM
+        s.playing = s === shootState
         s.loop = false
       }
       shootState.playing = true
@@ -183,7 +181,7 @@ export function createGun(upgradeLevel: number = 1): Entity {
   })
 
   Animator.create(gunModel, {
-    states: [{ clip: GUN_SHOOT_ANIM, playing: false, loop: false, speed: 1 }]
+    states: [{ clip: getArenaWeaponShootClip('gun', currentGunUpgradeLevel), playing: false, loop: false, speed: 1 }]
   })
 
   gunEntity = gun
@@ -253,7 +251,7 @@ export function gunSystem(dt: number) {
   }
 
   if (!gunEntity) {
-    if (!shouldShowDebugLobbyGun && getCurrentWeapon() !== 'gun') return
+    if (!shouldShowDebugLobbyGun) return
     createGun()
   }
 

--- a/src/loadoutState.ts
+++ b/src/loadoutState.ts
@@ -1,4 +1,10 @@
-import { LoadoutWeaponId, LOADOUT_WEAPON_DEFINITIONS, getLoadoutWeaponDefinition } from './shared/loadoutCatalog'
+import {
+  DEFAULT_LOADOUT_WEAPON_BY_TIER,
+  LoadoutTierKey,
+  LoadoutWeaponId,
+  LOADOUT_WEAPON_DEFINITIONS,
+  getLoadoutWeaponDefinition
+} from './shared/loadoutCatalog'
 
 export type PlayerLoadoutSnapshot = {
   gold: number
@@ -8,8 +14,8 @@ export type PlayerLoadoutSnapshot = {
 
 const defaultSnapshot: PlayerLoadoutSnapshot = {
   gold: 0,
-  ownedWeaponIds: ['gun_t1'],
-  equippedWeaponIds: ['gun_t1']
+  ownedWeaponIds: ['gun_t1', 'shotgun_t1', 'minigun_t1'],
+  equippedWeaponIds: ['gun_t1', 'shotgun_t1', 'minigun_t1']
 }
 
 let playerLoadoutSnapshot: PlayerLoadoutSnapshot = { ...defaultSnapshot }
@@ -27,18 +33,36 @@ function uniqueWeaponIds(weaponIds: string[]): LoadoutWeaponId[] {
   return filtered
 }
 
+function normalizeEquippedWeaponIds(weaponIds: string[], ownedWeaponIds: LoadoutWeaponId[]): LoadoutWeaponId[] {
+  const equippedByTier: Partial<Record<LoadoutTierKey, LoadoutWeaponId>> = {}
+
+  for (const weaponId of uniqueWeaponIds(weaponIds)) {
+    const weapon = getLoadoutWeaponDefinition(weaponId)
+    if (!weapon || !ownedWeaponIds.includes(weapon.id)) continue
+    equippedByTier[weapon.tierKey] = weapon.id
+  }
+
+  for (const [tierKey, weaponId] of Object.entries(DEFAULT_LOADOUT_WEAPON_BY_TIER) as Array<[LoadoutTierKey, LoadoutWeaponId]>) {
+    if (!equippedByTier[tierKey] || !ownedWeaponIds.includes(equippedByTier[tierKey]!)) {
+      equippedByTier[tierKey] = weaponId
+    }
+  }
+
+  const orderedTierKeys: LoadoutTierKey[] = ['tier1', 'tier2', 'tier3', 'tier4']
+  return orderedTierKeys.flatMap((tierKey) => (equippedByTier[tierKey] ? [equippedByTier[tierKey]!] : []))
+}
+
 export function applyPlayerLoadoutSnapshot(snapshot: {
   gold: number
   ownedWeaponIds: string[]
   equippedWeaponIds: string[]
 }): void {
   const ownedWeaponIds = uniqueWeaponIds(snapshot.ownedWeaponIds)
-  if (!ownedWeaponIds.includes('gun_t1')) ownedWeaponIds.unshift('gun_t1')
+  for (const weaponId of Object.values(DEFAULT_LOADOUT_WEAPON_BY_TIER)) {
+    if (weaponId && !ownedWeaponIds.includes(weaponId)) ownedWeaponIds.push(weaponId)
+  }
 
-  const equippedWeaponIds = uniqueWeaponIds(snapshot.equippedWeaponIds).filter((weaponId) =>
-    ownedWeaponIds.includes(weaponId)
-  )
-  if (!equippedWeaponIds.includes('gun_t1')) equippedWeaponIds.unshift('gun_t1')
+  const equippedWeaponIds = normalizeEquippedWeaponIds(snapshot.equippedWeaponIds, ownedWeaponIds)
 
   playerLoadoutSnapshot = {
     gold: Number.isFinite(snapshot.gold) ? Math.max(0, Math.floor(snapshot.gold)) : 0,

--- a/src/loadoutWorldPanel.ts
+++ b/src/loadoutWorldPanel.ts
@@ -299,7 +299,6 @@ export class LoadoutWorldPanel {
 
   private handleActionClick(): void {
     const weapon = this.getSelectedWeapon()
-    if (weapon.priceGold === 0) return
 
     if (!isLoadoutWeaponOwned(weapon.id)) {
       if (getPlayerGold() < weapon.priceGold) return
@@ -320,7 +319,7 @@ export class LoadoutWorldPanel {
 
     return [
       `Gold: ${getPlayerGold()}`,
-      'Default: Gun',
+      'Default loadout: base tiers included',
       `Weapon: ${weapon.label}`,
       `Arena tier: ${weapon.tierKey.toUpperCase()}`,
       `Price: ${weapon.priceGold} GOLD`,
@@ -344,7 +343,6 @@ export class LoadoutWorldPanel {
 
   private getActionLabel(): string {
     const weapon = this.getSelectedWeapon()
-    if (weapon.priceGold === 0) return 'Equipped'
     if (!isLoadoutWeaponOwned(weapon.id)) {
       return getPlayerGold() >= weapon.priceGold ? `Buy ${weapon.priceGold}G` : `Need ${weapon.priceGold}G`
     }

--- a/src/lobbyStoreUi.tsx
+++ b/src/lobbyStoreUi.tsx
@@ -8,8 +8,8 @@ import {
   ArenaWeaponType,
   getWeaponUpgrades
 } from './shared/loadoutCatalog'
-import { getPlayerGold, isLoadoutWeaponOwned } from './loadoutState'
-import { sendBuyLoadoutWeapon, sendRequestLoadoutRefresh } from './multiplayer/lobbyClient'
+import { getPlayerGold, isLoadoutWeaponEquipped, isLoadoutWeaponOwned } from './loadoutState'
+import { sendBuyLoadoutWeapon, sendEquipLoadoutWeapon, sendRequestLoadoutRefresh } from './multiplayer/lobbyClient'
 import { endUiPointerCapture } from './gameplayInput'
 
 let storeOpen = false
@@ -346,6 +346,7 @@ function WeaponRow({ weaponType, isLast }: { weaponType: ArenaWeaponType; isLast
 function DetailPanel({ weapon }: { weapon: LoadoutWeaponDefinition }) {
   const { DETAIL_PANEL_W, DETAIL_TITLE_H, DETAIL_SUBTITLE_H, STORE_GRID_HEIGHT } = getStoreMetrics()
   const owned = isLoadoutWeaponOwned(weapon.id)
+  const equipped = isLoadoutWeaponEquipped(weapon.id)
   const unlocked = isPreviousOwned(weapon)
   const gold = getPlayerGold()
   const canAfford = gold >= weapon.priceGold
@@ -435,16 +436,24 @@ function DetailPanel({ weapon }: { weapon: LoadoutWeaponDefinition }) {
 
       <UiEntity uiTransform={{ flexDirection: 'column', alignItems: 'center', width: '100%' }}>
         <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { bottom: scaleStoreSpacing(8) } }}>
-          <Label value="GOLD: " fontSize={scaleStoreFont(16)} color={C.textGray} />
-          <Label value={`${gold}`} fontSize={scaleStoreFont(22)} color={C.textGold} />
+          <Label
+            value={owned ? 'OWNED' : `PRICE: ${weapon.priceGold} G`}
+            fontSize={scaleStoreFont(20)}
+            color={owned ? C.textGreen : C.textGold}
+          />
         </UiEntity>
 
         {owned ? (
           <UiEntity
             uiTransform={{ width: '100%', height: scaleStoreButton(36), borderRadius: 8, alignItems: 'center', justifyContent: 'center' }}
-            uiBackground={{ color: C.btnOwned }}
+            uiBackground={{ color: equipped ? C.btnOwned : C.btnBuy }}
+            onMouseDown={equipped ? undefined : () => sendEquipLoadoutWeapon(weapon.id)}
           >
-            <Label value="✓ OWNED" fontSize={scaleStoreFont(24)} color={C.textGreen} />
+            <Label
+              value={equipped ? 'EQUIPPED' : 'EQUIP'}
+              fontSize={scaleStoreFont(24)}
+              color={equipped ? C.textGreen : C.textWhite}
+            />
           </UiEntity>
         ) : !unlocked ? (
           <UiEntity
@@ -460,7 +469,7 @@ function DetailPanel({ weapon }: { weapon: LoadoutWeaponDefinition }) {
             onMouseDown={canAfford ? () => sendBuyLoadoutWeapon(weapon.id) : undefined}
           >
             <Label
-              value={canAfford ? `BUY  ${weapon.priceGold} G` : `Need ${weapon.priceGold} G`}
+              value="BUY"
               fontSize={scaleStoreFont(20)}
               color={canAfford ? C.textWhite : C.textGray}
             />

--- a/src/miniGun.ts
+++ b/src/miniGun.ts
@@ -30,9 +30,7 @@ import {
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
 
-import { getArenaWeaponModelPath } from './shared/loadoutCatalog'
-
-const GUN_SHOOT_ANIM = 'DroneMinigunShoot'
+import { getArenaWeaponModelPath, getArenaWeaponShootClip } from './shared/loadoutCatalog'
 
 // Gun config - tweak these to your liking
 const ROUNDS_PER_SECOND = 5 // Minigun fires faster
@@ -106,10 +104,10 @@ function getNearestZombie(fromPosition: Vector3): Entity | null {
 function playGunAnimation() {
   if (gunModelEntity && Animator.has(gunModelEntity)) {
     const animator = Animator.getMutable(gunModelEntity)
-    const shootState = animator.states.find((s) => s.clip === GUN_SHOOT_ANIM)
+    const shootState = animator.states[0]
     if (shootState) {
       for (const s of animator.states) {
-        s.playing = s.clip === GUN_SHOOT_ANIM
+        s.playing = s === shootState
         s.loop = false
       }
       shootState.playing = true
@@ -190,7 +188,7 @@ export function createMiniGun(upgradeLevel: number = 1): Entity {
   })
 
   Animator.create(gunModel, {
-    states: [{ clip: GUN_SHOOT_ANIM, playing: false, loop: false, speed: 1 }]
+    states: [{ clip: getArenaWeaponShootClip('minigun', upgradeLevel), playing: false, loop: false, speed: 1 }]
   })
 
   gunEntity = gun

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -28,7 +28,13 @@ import {
   WAVE_ACTIVE_SECONDS,
   WAVE_REST_SECONDS
 } from '../shared/matchConfig'
-import { ArenaWeaponType, LoadoutWeaponId, LOADOUT_WEAPON_DEFINITIONS, getLoadoutWeaponDefinition } from '../shared/loadoutCatalog'
+import {
+  ArenaWeaponType,
+  DEFAULT_LOADOUT_WEAPON_BY_TIER,
+  LoadoutWeaponId,
+  LOADOUT_WEAPON_DEFINITIONS,
+  getLoadoutWeaponDefinition
+} from '../shared/loadoutCatalog'
 import { createPlayerProgressStore } from './storage/playerProgress'
 import { getServerTime } from '../shared/timeSync'
 import {
@@ -161,11 +167,14 @@ function logLobbyServerEvent(message: string): void {
 }
 
 function getOwnedWeaponIds(address: string): LoadoutWeaponId[] {
+  const defaultOwnedWeaponIds = Object.values(DEFAULT_LOADOUT_WEAPON_BY_TIER).filter(
+    (weaponId): weaponId is LoadoutWeaponId => !!weaponId
+  )
   const progress = playerProgressStore.get(address)
-  if (!progress) return ['gun_t1']
+  if (!progress) return defaultOwnedWeaponIds
 
   const validIds = VALID_WEAPON_IDS
-  const ownedWeaponIds: LoadoutWeaponId[] = ['gun_t1']
+  const ownedWeaponIds: LoadoutWeaponId[] = [...defaultOwnedWeaponIds]
 
   for (const tier of ['tier1', 'tier2', 'tier3', 'tier4'] as const) {
     for (const weaponId of progress.weapons.ownedByTier[tier]) {
@@ -199,10 +208,13 @@ function getExplosiveZombieDamageKey(address: string, zombieId: string): string 
 
 function getEquippedWeaponIds(address: string): LoadoutWeaponId[] {
   const progress = playerProgressStore.get(address)
-  if (!progress) return ['gun_t1']
+  const defaultEquippedWeaponIds = Object.values(DEFAULT_LOADOUT_WEAPON_BY_TIER).filter(
+    (weaponId): weaponId is LoadoutWeaponId => !!weaponId
+  )
+  if (!progress) return defaultEquippedWeaponIds
 
   const validIds = VALID_WEAPON_IDS
-  const equippedWeaponIds: LoadoutWeaponId[] = ['gun_t1']
+  const equippedWeaponIds: LoadoutWeaponId[] = []
 
   for (const tier of ['tier1', 'tier2', 'tier3', 'tier4'] as const) {
     const id = progress.weapons.equippedByTier[tier]
@@ -210,6 +222,18 @@ function getEquippedWeaponIds(address: string): LoadoutWeaponId[] {
       equippedWeaponIds.push(id as LoadoutWeaponId)
     }
   }
+
+  for (const [tierKey, weaponId] of Object.entries(DEFAULT_LOADOUT_WEAPON_BY_TIER)) {
+    if (!weaponId) continue
+    const alreadyEquippedInTier = equippedWeaponIds.some((equippedWeaponId) => {
+      const weapon = getLoadoutWeaponDefinition(equippedWeaponId)
+      return weapon?.tierKey === tierKey
+    })
+    if (!alreadyEquippedInTier) {
+      equippedWeaponIds.push(weaponId)
+    }
+  }
+
   return equippedWeaponIds
 }
 
@@ -1311,13 +1335,14 @@ export function setupLobbyServer(): void {
     playerProgressStore.mutate(normalizedAddress, (state) => {
       state.profile.gold -= weapon.priceGold
       state.weapons.ownedByTier[weapon.tierKey] = [...state.weapons.ownedByTier[weapon.tierKey], weapon.id]
+      state.weapons.equippedByTier[weapon.tierKey] = weapon.id
     })
     await playerProgressStore.save(normalizedAddress)
     sendPlayerLoadoutState(normalizedAddress)
 
     void room.send('lobbyEvent', {
       type: 'loadout_purchase',
-      message: `${weapon.label} purchased for ${weapon.priceGold} GOLD`
+      message: `${weapon.label} purchased and equipped for ${weapon.priceGold} GOLD`
     })
   })
 

--- a/src/server/storage/playerProgress.ts
+++ b/src/server/storage/playerProgress.ts
@@ -1,4 +1,5 @@
 import { Storage } from '@dcl/sdk/server'
+import { DEFAULT_LOADOUT_WEAPON_BY_TIER } from '../../shared/loadoutCatalog'
 
 const PROFILE_KEY = 'profile_v1'
 const WEAPONS_KEY = 'weapons_v1'
@@ -49,14 +50,14 @@ function emptyWeapons(): PlayerWeaponsV1 {
     schemaVersion: SCHEMA_VERSION,
     ownedByTier: {
       tier1: ['gun_t1'],
-      tier2: [],
-      tier3: [],
+      tier2: ['shotgun_t1'],
+      tier3: ['minigun_t1'],
       tier4: []
     },
     equippedByTier: {
       tier1: 'gun_t1',
-      tier2: '',
-      tier3: '',
+      tier2: 'shotgun_t1',
+      tier3: 'minigun_t1',
       tier4: ''
     },
     updatedAt: nowMs()
@@ -118,21 +119,42 @@ function normalizeWeapons(value: unknown): PlayerWeaponsV1 {
   if (!maybe || maybe.schemaVersion !== SCHEMA_VERSION) return fallback
 
   const safeArray = (arr: unknown): string[] => (Array.isArray(arr) ? arr.filter((v) => typeof v === 'string') : [])
+  const ownedByTier = {
+    tier1: safeArray(maybe.ownedByTier?.tier1),
+    tier2: safeArray(maybe.ownedByTier?.tier2),
+    tier3: safeArray(maybe.ownedByTier?.tier3),
+    tier4: safeArray(maybe.ownedByTier?.tier4)
+  }
+
+  for (const [tierKey, weaponId] of Object.entries(DEFAULT_LOADOUT_WEAPON_BY_TIER) as Array<[TierKey, string]>) {
+    if (!ownedByTier[tierKey].includes(weaponId)) {
+      ownedByTier[tierKey].unshift(weaponId)
+    }
+  }
+
+  const equippedByTier = {
+    tier1: typeof maybe.equippedByTier?.tier1 === 'string' && maybe.equippedByTier.tier1 ? maybe.equippedByTier.tier1 : 'gun_t1',
+    tier2:
+      typeof maybe.equippedByTier?.tier2 === 'string' && maybe.equippedByTier.tier2
+        ? maybe.equippedByTier.tier2
+        : 'shotgun_t1',
+    tier3:
+      typeof maybe.equippedByTier?.tier3 === 'string' && maybe.equippedByTier.tier3
+        ? maybe.equippedByTier.tier3
+        : 'minigun_t1',
+    tier4: typeof maybe.equippedByTier?.tier4 === 'string' ? maybe.equippedByTier.tier4 : ''
+  }
+
+  for (const [tierKey, weaponId] of Object.entries(DEFAULT_LOADOUT_WEAPON_BY_TIER) as Array<[TierKey, string]>) {
+    if (!ownedByTier[tierKey].includes(equippedByTier[tierKey])) {
+      equippedByTier[tierKey] = weaponId
+    }
+  }
 
   return {
     schemaVersion: SCHEMA_VERSION,
-    ownedByTier: {
-      tier1: safeArray(maybe.ownedByTier?.tier1),
-      tier2: safeArray(maybe.ownedByTier?.tier2),
-      tier3: safeArray(maybe.ownedByTier?.tier3),
-      tier4: safeArray(maybe.ownedByTier?.tier4)
-    },
-    equippedByTier: {
-      tier1: typeof maybe.equippedByTier?.tier1 === 'string' ? maybe.equippedByTier.tier1 : 'gun_t1',
-      tier2: typeof maybe.equippedByTier?.tier2 === 'string' ? maybe.equippedByTier.tier2 : '',
-      tier3: typeof maybe.equippedByTier?.tier3 === 'string' ? maybe.equippedByTier.tier3 : '',
-      tier4: typeof maybe.equippedByTier?.tier4 === 'string' ? maybe.equippedByTier.tier4 : ''
-    },
+    ownedByTier,
+    equippedByTier,
     updatedAt: typeof maybe.updatedAt === 'number' && Number.isFinite(maybe.updatedAt) ? maybe.updatedAt : nowMs()
   }
 }

--- a/src/shared/loadoutCatalog.ts
+++ b/src/shared/loadoutCatalog.ts
@@ -17,6 +17,12 @@ export type LoadoutWeaponDefinition = {
   previewLabel: string
 }
 
+export const DEFAULT_LOADOUT_WEAPON_BY_TIER: Partial<Record<LoadoutTierKey, LoadoutWeaponId>> = {
+  tier1: 'gun_t1',
+  tier2: 'shotgun_t1',
+  tier3: 'minigun_t1'
+}
+
 export const LOADOUT_WEAPON_DEFINITIONS: LoadoutWeaponDefinition[] = [
   {
     id: 'gun_t1',
@@ -51,7 +57,7 @@ export const LOADOUT_WEAPON_DEFINITIONS: LoadoutWeaponDefinition[] = [
     arenaWeaponType: 'shotgun',
     tierKey: 'tier2',
     upgradeLevel: 1,
-    priceGold: 2,
+    priceGold: 0,
     previewLabel: 'Close-range spread'
   },
   {
@@ -78,7 +84,7 @@ export const LOADOUT_WEAPON_DEFINITIONS: LoadoutWeaponDefinition[] = [
     arenaWeaponType: 'minigun',
     tierKey: 'tier3',
     upgradeLevel: 1,
-    priceGold: 5,
+    priceGold: 0,
     previewLabel: 'Heavy sustained fire'
   },
   {
@@ -127,4 +133,24 @@ export function getArenaWeaponModelPath(weaponType: ArenaWeaponType, upgradeLeve
     return 'assets/scene/Models/drones/minigun/DroneMinigun.glb'
   }
   return 'assets/scene/Models/drones/gun/DroneGun.glb'
+}
+
+export function getArenaWeaponShootClip(weaponType: ArenaWeaponType, upgradeLevel: number): string {
+  const level = Math.max(1, Math.min(3, upgradeLevel))
+  if (weaponType === 'gun') {
+    if (level === 3) return 'DroneGunGoldShoot'
+    if (level === 2) return 'DroneGunUp1Shoot'
+    return 'DroneGunShoot'
+  }
+  if (weaponType === 'shotgun') {
+    if (level === 3) return 'DroneShotGunGoldShoot'
+    if (level === 2) return 'DroneShotGunUp1Shoot'
+    return 'DroneShotGunShoot'
+  }
+  if (weaponType === 'minigun') {
+    if (level === 3) return 'DroneMinigunGoldShoot'
+    if (level === 2) return 'DroneMinigunUp1Shoot'
+    return 'DroneMinigunShoot'
+  }
+  return 'DroneGunShoot'
 }

--- a/src/shotGun.ts
+++ b/src/shotGun.ts
@@ -25,9 +25,7 @@ import {
   WEAPON_ROOT_OFFSET
 } from './shared/weaponVisuals'
 
-import { getArenaWeaponModelPath } from './shared/loadoutCatalog'
-
-const GUN_SHOOT_ANIM = 'DroneShotGunShoot'
+import { getArenaWeaponModelPath, getArenaWeaponShootClip } from './shared/loadoutCatalog'
 
 // Gun config - tweak these to your liking
 const ROUNDS_PER_SECOND = 2 // Manual fire rate: 1 shot every 0.5s
@@ -65,10 +63,10 @@ function getNearestZombie(fromPosition: Vector3): Entity | null {
 function playGunAnimation() {
   if (gunModelEntity && Animator.has(gunModelEntity)) {
     const animator = Animator.getMutable(gunModelEntity)
-    const shootState = animator.states.find((s) => s.clip === GUN_SHOOT_ANIM)
+    const shootState = animator.states[0]
     if (shootState) {
       for (const s of animator.states) {
-        s.playing = s.clip === GUN_SHOOT_ANIM
+        s.playing = s === shootState
         s.loop = false
       }
       shootState.playing = true
@@ -160,7 +158,7 @@ export function createShotGun(upgradeLevel: number = 1): Entity {
   })
 
   Animator.create(gunModel, {
-    states: [{ clip: GUN_SHOOT_ANIM, playing: false, loop: false, speed: 1 }]
+    states: [{ clip: getArenaWeaponShootClip('shotgun', upgradeLevel), playing: false, loop: false, speed: 1 }]
   })
 
   gunEntity = gun

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -96,23 +96,11 @@ const LOBBY_HUD_GOLD_SOURCE_HEIGHT = 174
 const LOBBY_HUD_GOLD_WIDTH = Math.round(LOBBY_HUD_GOLD_SOURCE_WIDTH * 0.5)
 const LOBBY_HUD_GOLD_HEIGHT = Math.round(LOBBY_HUD_GOLD_SOURCE_HEIGHT * 0.5)
 const LOBBY_HUD_GOLD_UVS = createAtlasUvs(425, 335, LOBBY_HUD_GOLD_SOURCE_WIDTH, LOBBY_HUD_GOLD_SOURCE_HEIGHT)
-const LOBBY_HUD_LOADOUT_SOURCE_WIDTH = 886
-const LOBBY_HUD_LOADOUT_SOURCE_HEIGHT = 160
-const LOBBY_HUD_LOADOUT_WIDTH = Math.round(LOBBY_HUD_LOADOUT_SOURCE_WIDTH * 0.5)
-const LOBBY_HUD_LOADOUT_HEIGHT = Math.round(LOBBY_HUD_LOADOUT_SOURCE_HEIGHT * 0.5)
-const LOBBY_HUD_LOADOUT_UVS = createAtlasUvs(
-  322,
-  593,
-  LOBBY_HUD_LOADOUT_SOURCE_WIDTH,
-  LOBBY_HUD_LOADOUT_SOURCE_HEIGHT
-)
 const LOBBY_HUD_SHOP_SOURCE_WIDTH = 814
 const LOBBY_HUD_SHOP_SOURCE_HEIGHT = 178
 const LOBBY_HUD_SHOP_WIDTH = Math.round(LOBBY_HUD_SHOP_SOURCE_WIDTH * 0.5)
 const LOBBY_HUD_SHOP_HEIGHT = Math.round(LOBBY_HUD_SHOP_SOURCE_HEIGHT * 0.5)
 const LOBBY_HUD_SHOP_UVS = createAtlasUvs(346, 80, LOBBY_HUD_SHOP_SOURCE_WIDTH, LOBBY_HUD_SHOP_SOURCE_HEIGHT)
-const LOBBY_HUD_TOP_ACTION_GAP = 20
-const LOBBY_HUD_TOP_ACTION_OFFSET = Math.round((LOBBY_HUD_SHOP_WIDTH + LOBBY_HUD_TOP_ACTION_GAP) * 0.5)
 const LOBBY_HUD_GOLD_TOP = Math.round((1080 - (LOBBY_HUD_GOLD_HEIGHT + LOBBY_HUD_ITEM_MARGIN_BOTTOM + LOBBY_HUD_SHOP_HEIGHT)) * 0.5)
 
 type AtlasUvs = [number, number, number, number, number, number, number, number]
@@ -655,9 +643,8 @@ export const uiMenu = () => {
         >
           <UiEntity
             uiTransform={{
-              flexDirection: 'row',
               alignItems: 'center',
-              margin: { left: LOBBY_HUD_TOP_ACTION_OFFSET }
+              justifyContent: 'center'
             }}
           >
             <UiEntity
@@ -675,18 +662,6 @@ export const uiMenu = () => {
                 openLobbyStore()
               }}
               onMouseUp={endUiPointerCapture}
-            />
-            <UiEntity
-              uiTransform={{
-                width: LOBBY_HUD_LOADOUT_WIDTH,
-                height: LOBBY_HUD_LOADOUT_HEIGHT,
-                margin: { left: LOBBY_HUD_TOP_ACTION_GAP }
-              }}
-              uiBackground={{
-                textureMode: 'stretch',
-                texture: { src: HUD_LOBBY_SHEET_SRC, filterMode: 'tri-linear', wrapMode: 'clamp' },
-                uvs: LOBBY_HUD_LOADOUT_UVS
-              }}
             />
           </UiEntity>
         </UiEntity>

--- a/src/weaponManager.ts
+++ b/src/weaponManager.ts
@@ -19,6 +19,7 @@ let weaponHiddenByDeath = false
 let lifecycleSystemInitialized = false
 let shotgunPurchasedInMatch = false
 let minigunPurchasedInMatch = false
+let spawnedWeaponUpgradeLevel = 1
 
 export function getCurrentWeapon(): WeaponType {
   return currentWeapon
@@ -59,11 +60,14 @@ export function purchaseWeapon(type: WeaponType): boolean {
 
 function getEquippedUpgradeLevel(type: WeaponType): number {
   const snapshot = getPlayerLoadoutSnapshot()
+  let matchedUpgradeLevel = 1
   for (const weaponId of snapshot.equippedWeaponIds) {
     const def = getLoadoutWeaponDefinition(weaponId)
-    if (def?.arenaWeaponType === type) return def.upgradeLevel
+    if (def?.arenaWeaponType === type) {
+      matchedUpgradeLevel = Math.max(matchedUpgradeLevel, def.upgradeLevel)
+    }
   }
-  return 1
+  return matchedUpgradeLevel
 }
 
 function destroyCurrentWeapon(): void {
@@ -72,6 +76,7 @@ function destroyCurrentWeapon(): void {
   else if (currentWeapon === 'shotgun') destroyShotGun()
   else if (currentWeapon === 'minigun') destroyMiniGun()
   hasSpawnedWeapon = false
+  spawnedWeaponUpgradeLevel = 1
 }
 
 function createWeapon(type: WeaponType): void {
@@ -80,6 +85,7 @@ function createWeapon(type: WeaponType): void {
   else if (type === 'shotgun') createShotGun(upgradeLevel)
   else if (type === 'minigun') createMiniGun(upgradeLevel)
   hasSpawnedWeapon = true
+  spawnedWeaponUpgradeLevel = upgradeLevel
   sendPlayerArenaWeaponChanged(type, upgradeLevel)
 }
 
@@ -131,6 +137,15 @@ function weaponLifecycleSystem(): void {
   if (weaponHiddenByDeath && !hasSpawnedWeapon) {
     createWeapon(currentWeapon)
     weaponHiddenByDeath = false
+    return
+  }
+
+  if (hasSpawnedWeapon) {
+    const desiredUpgradeLevel = getEquippedUpgradeLevel(currentWeapon)
+    if (desiredUpgradeLevel !== spawnedWeaponUpgradeLevel) {
+      destroyCurrentWeapon()
+      createWeapon(currentWeapon)
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes the loadout upgrade flow and cleans up the lobby shop experience.

Key changes:

- Fixed loadout purchases so bought upgrades are persisted and auto-equipped.
- Fixed arena weapon upgrade resolution so the correct upgraded weapon model is spawned in match.
- Fixed upgraded weapon animations by mapping the correct animation clip per GLB variant.
- Made shotgun_t1 and minigun_t1 part of the default loadout, while keeping their in-match unlock flow unchanged.
- Removed the temporary debug gold override.
- Simplified the lobby UI by hiding the unused Loadout HUD button, centering the Shop button, and cleaning up the store detail panel:
  1.   removed the player gold display from the weapon detail area
  2.   show weapon price or owned state instead
  3.   simplified the buy button label to BUY

Closes #183 
Closes #184 