### PR TITLE
Fix lobby start debug fallback

### DIFF
--- a/src/lobbyWorldPanel.ts
+++ b/src/lobbyWorldPanel.ts
@@ -163,10 +163,6 @@ export class LobbyWorldPanel {
   }
 
   private buildCountdownText(): string {
-    const lobby = getLobbyState()
-    if (lobby?.countdownEndTimeMs && lobby.countdownEndTimeMs > 0) {
-      return `${Math.max(0, Math.ceil((lobby.countdownEndTimeMs - getServerTime()) / 1000))}`
-    }
     return ''
   }
 

--- a/src/multiplayer/lobbyClient.ts
+++ b/src/multiplayer/lobbyClient.ts
@@ -1,7 +1,7 @@
 import { engine, PlayerIdentityData, RealmInfo } from '@dcl/sdk/ecs'
 import { room } from '../shared/messages'
-import { LobbyStateComponent, LobbyStateSnapshot } from '../shared/lobbySchemas'
-import { MatchRuntimeSnapshot, MatchRuntimeStateComponent } from '../shared/matchRuntimeSchemas'
+import { LobbyPhase, LobbyPlayer, LobbyStateComponent, LobbyStateSnapshot } from '../shared/lobbySchemas'
+import { MatchRuntimeSnapshot, MatchRuntimeStateComponent, WaveCyclePhase } from '../shared/matchRuntimeSchemas'
 import { movePlayerTo } from '~system/RestrictedActions'
 import { Vector3 } from '@dcl/sdk/math'
 import { applyAuthoritativeHealthState, resetPlayerHealthState } from '../playerHealth'
@@ -10,6 +10,9 @@ import { applyPlayerLoadoutSnapshot } from '../loadoutState'
 import { enableArenaWeapon, resetArenaWeaponProgress } from '../weaponManager'
 import { resetToIdle } from '../waveManager'
 import { ArenaWeaponType } from '../shared/loadoutCatalog'
+import { WAVE_ACTIVE_SECONDS, WAVE_REST_SECONDS } from '../shared/matchConfig'
+import { ARENA_CENTER_X, ARENA_CENTER_Z } from '../shared/arenaConfig'
+import { getServerTime } from '../shared/timeSync'
 
 let latestLobbyEvent = ''
 let latestLobbyEventType = ''
@@ -17,10 +20,21 @@ let latestLobbyEventAtMs = 0
 let hasProfileLoadSent = false
 let localReadyForMatch = false
 let lastTeamWipeAffectedLocalPlayer = false
+let sceneRoomConnectedAtMs = 0
+let localAuthDebugActive = false
+let debugLobbyState: LobbyStateSnapshot | null = null
+let debugMatchRuntimeState: MatchRuntimeSnapshot | null = null
 const GAME_OVER_OVERLAY_DELAY_MS = 2000
 const playerCombatStateByAddress = new Map<string, { hp: number; isDead: boolean; respawnAtMs: number; updatedAtMs: number }>()
 const playerArenaWeaponByAddress = new Map<string, { weaponType: ArenaWeaponType; upgradeLevel: number }>()
 const playerPowerupStateByAddress = new Map<string, { rageShieldEndAtMs: number; speedEndAtMs: number }>()
+const ENABLE_LOCAL_AUTH_DEBUG_IN_PREVIEW = false
+const LOCAL_AUTH_DEBUG_GRACE_MS = 2500
+const LOCAL_AUTH_DEBUG_AUTO_TELEPORT_COUNTDOWN_SECONDS = 5
+const LOCAL_AUTH_DEBUG_ARENA_INTRO_SECONDS = 5
+const DEBUG_MATCH_ID_PREFIX = 'debug_local_match_'
+const DEBUG_ARENA_POSITION = { x: ARENA_CENTER_X, y: 0, z: ARENA_CENTER_Z }
+const DEBUG_ARENA_LOOK_AT = { x: ARENA_CENTER_X, y: 1, z: ARENA_CENTER_Z + 1 }
 
 function resetLocalMatchUiState(): void {
   localReadyForMatch = false
@@ -129,22 +143,39 @@ export function setupLobbyClient(): void {
   })
 
   engine.addSystem(autoJoinLobbySystem, undefined, 'auto-join-lobby-client-system')
+  engine.addSystem(localAuthDebugSystem, undefined, 'local-auth-debug-system')
 }
 
 export function sendLoadProfile(): void {
+  if (localAuthDebugActive) {
+    console.log(`[LobbyClientDebug] skip remote playerLoadProfile addr=${getLocalAddress() || 'none'}`)
+    return
+  }
   void room.send('playerLoadProfile', {})
 }
 
 export function sendRequestLoadoutRefresh(): void {
+  if (localAuthDebugActive) {
+    console.log('[LobbyClientDebug] skip remote loadout refresh')
+    return
+  }
   void room.send('playerLoadProfile', {})
 }
 
 export function sendJoinLobby(): void {
+  if (ensureLocalAuthDebugActive('joinLobby')) {
+    debugJoinLobbyOnly()
+    return
+  }
   void room.send('playerJoinLobby', {})
 }
 
 export function sendLeaveLobby(): void {
   resetLocalMatchUiState()
+  if (ensureLocalAuthDebugActive('leaveLobby')) {
+    debugLeaveLobby()
+    return
+  }
   void room.send('playerLeaveLobby', {})
 }
 
@@ -157,14 +188,26 @@ export function sendEquipLoadoutWeapon(weaponId: string): void {
 }
 
 export function sendCreateMatch(): void {
+  if (ensureLocalAuthDebugActive('createMatch')) {
+    debugCreateMatch()
+    return
+  }
   void room.send('createMatch', {})
 }
 
 export function sendCreateMatchAndJoin(): void {
+  if (ensureLocalAuthDebugActive('createMatchAndJoin')) {
+    debugCreateMatchAndJoin()
+    return
+  }
   void room.send('createMatchAndJoin', {})
 }
 
 export function sendStartGameManual(): void {
+  if (ensureLocalAuthDebugActive('startGameManual')) {
+    debugStartGameManual()
+    return
+  }
   void room.send('startGameManual', {})
 }
 
@@ -217,23 +260,300 @@ export function getLocalAddress(): string {
 }
 
 function autoJoinLobbySystem(): void {
+  const sceneRoomConnected = isSceneRoomConnected()
+  if (sceneRoomConnected && sceneRoomConnectedAtMs <= 0) {
+    sceneRoomConnectedAtMs = Date.now()
+  }
+  if (!sceneRoomConnected) {
+    sceneRoomConnectedAtMs = 0
+  }
+
   if (hasProfileLoadSent) return
   const localAddress = getLocalAddress()
   if (!localAddress) return
 
-  const realmInfo = RealmInfo.getOrNull(engine.RootEntity)
-  if (!realmInfo?.isConnectedSceneRoom) return
+  if (ensureLocalAuthDebugActive('autoJoinLobbySystem')) {
+    hasProfileLoadSent = true
+    console.log(`[LobbyClientDebug] local auth debug ready for ${localAddress}`)
+    return
+  }
+
+  if (!sceneRoomConnected) return
 
   hasProfileLoadSent = true
   sendLoadProfile()
 }
 
+function localAuthDebugSystem(): void {
+  if (!localAuthDebugActive) {
+    ensureLocalAuthDebugActive('autoJoinLobbySystem')
+    return
+  }
+
+  const lobby = ensureDebugLobbyState()
+  const runtime = ensureDebugMatchRuntimeState()
+  const nowMs = getServerTime()
+  runtime.serverNowMs = nowMs
+
+  if (lobby.countdownEndTimeMs > 0 && lobby.countdownEndTimeMs <= nowMs) {
+    lobby.countdownEndTimeMs = 0
+    lobby.arenaIntroEndTimeMs = nowMs + LOCAL_AUTH_DEBUG_ARENA_INTRO_SECONDS * 1000
+    localReadyForMatch = true
+    movePlayerTo({
+      newRelativePosition: DEBUG_ARENA_POSITION,
+      cameraTarget: DEBUG_ARENA_LOOK_AT
+    })
+    console.log('[LobbyClientDebug] local arena teleport fired')
+  }
+
+  if (lobby.arenaIntroEndTimeMs > 0 && lobby.arenaIntroEndTimeMs <= nowMs) {
+    lobby.arenaIntroEndTimeMs = 0
+    runtime.isRunning = true
+    runtime.waveNumber = Math.max(1, runtime.waveNumber || 1)
+    runtime.cyclePhase = WaveCyclePhase.ACTIVE
+    runtime.phaseEndTimeMs = nowMs + runtime.activeDurationSeconds * 1000
+    runtime.startedByAddress = lobby.hostAddress
+    enableArenaWeapon()
+    latestLobbyEvent = `Debug wave ${runtime.waveNumber} started`
+    latestLobbyEventType = 'waves_started'
+    latestLobbyEventAtMs = Date.now()
+    console.log('[LobbyClientDebug] match runtime started')
+  }
+
+  if (!runtime.isRunning || runtime.phaseEndTimeMs <= 0 || runtime.phaseEndTimeMs > nowMs) return
+
+  if (runtime.cyclePhase === WaveCyclePhase.ACTIVE) {
+    runtime.cyclePhase = WaveCyclePhase.REST
+    runtime.phaseEndTimeMs = nowMs + runtime.restDurationSeconds * 1000
+    latestLobbyEvent = `Debug rest after wave ${runtime.waveNumber}`
+    latestLobbyEventType = 'wave_rest'
+    latestLobbyEventAtMs = Date.now()
+    return
+  }
+
+  runtime.cyclePhase = WaveCyclePhase.ACTIVE
+  runtime.waveNumber += 1
+  runtime.phaseEndTimeMs = nowMs + runtime.activeDurationSeconds * 1000
+  latestLobbyEvent = `Debug wave ${runtime.waveNumber} started`
+  latestLobbyEventType = 'waves_started'
+  latestLobbyEventAtMs = Date.now()
+}
+
+function isSceneRoomConnected(): boolean {
+  const realmInfo = RealmInfo.getOrNull(engine.RootEntity)
+  return !!realmInfo?.isConnectedSceneRoom
+}
+
+function isPreviewMode(): boolean {
+  const realmInfo = RealmInfo.getOrNull(engine.RootEntity)
+  return !!realmInfo?.isPreview
+}
+
+function hasAuthoritativeLobbyState(): boolean {
+  for (const _ of engine.getEntitiesWith(LobbyStateComponent)) return true
+  return false
+}
+
+function hasAuthoritativeMatchRuntimeState(): boolean {
+  for (const _ of engine.getEntitiesWith(MatchRuntimeStateComponent)) return true
+  return false
+}
+
+function ensureLocalAuthDebugActive(
+  reason: 'autoJoinLobbySystem' | 'joinLobby' | 'leaveLobby' | 'createMatch' | 'createMatchAndJoin' | 'startGameManual'
+): boolean {
+  if (localAuthDebugActive) return true
+  if (!ENABLE_LOCAL_AUTH_DEBUG_IN_PREVIEW) return false
+  if (!isPreviewMode()) return false
+  if (!isSceneRoomConnected()) return false
+  if (hasAuthoritativeLobbyState() || hasAuthoritativeMatchRuntimeState()) return false
+
+  const nowMs = Date.now()
+  const graceElapsed =
+    sceneRoomConnectedAtMs > 0 && nowMs - sceneRoomConnectedAtMs >= LOCAL_AUTH_DEBUG_GRACE_MS
+  const shouldForceForAction =
+    reason === 'joinLobby' ||
+    reason === 'leaveLobby' ||
+    reason === 'createMatch' ||
+    reason === 'createMatchAndJoin' ||
+    reason === 'startGameManual'
+  if (!graceElapsed && !shouldForceForAction) return false
+
+  localAuthDebugActive = true
+  console.log(`[LobbyClientDebug] activated local auth debug (${reason})`)
+  return true
+}
+
+function ensureDebugLobbyState(): LobbyStateSnapshot {
+  if (debugLobbyState) return debugLobbyState
+  debugLobbyState = {
+    phase: LobbyPhase.LOBBY,
+    matchId: '',
+    hostAddress: '',
+    players: [],
+    arenaPlayers: [],
+    countdownEndTimeMs: 0,
+    arenaIntroEndTimeMs: 0
+  }
+  return debugLobbyState
+}
+
+function ensureDebugMatchRuntimeState(): MatchRuntimeSnapshot {
+  if (debugMatchRuntimeState) return debugMatchRuntimeState
+  debugMatchRuntimeState = {
+    isRunning: false,
+    waveNumber: 0,
+    cyclePhase: WaveCyclePhase.ACTIVE,
+    serverNowMs: Date.now(),
+    phaseEndTimeMs: 0,
+    activeDurationSeconds: WAVE_ACTIVE_SECONDS,
+    restDurationSeconds: WAVE_REST_SECONDS,
+    startedByAddress: '',
+    zombiesAlive: 0,
+    zombiesPlanned: 0
+  }
+  return debugMatchRuntimeState
+}
+
+function cloneLobbyState(state: LobbyStateSnapshot): LobbyStateSnapshot {
+  return {
+    phase: state.phase,
+    matchId: state.matchId,
+    hostAddress: state.hostAddress,
+    players: [...state.players],
+    arenaPlayers: [...state.arenaPlayers],
+    countdownEndTimeMs: state.countdownEndTimeMs,
+    arenaIntroEndTimeMs: state.arenaIntroEndTimeMs
+  }
+}
+
+function cloneMatchRuntimeState(state: MatchRuntimeSnapshot): MatchRuntimeSnapshot {
+  return {
+    isRunning: state.isRunning,
+    waveNumber: state.waveNumber,
+    cyclePhase: state.cyclePhase,
+    serverNowMs: state.serverNowMs,
+    phaseEndTimeMs: state.phaseEndTimeMs,
+    activeDurationSeconds: state.activeDurationSeconds,
+    restDurationSeconds: state.restDurationSeconds,
+    startedByAddress: state.startedByAddress,
+    zombiesAlive: state.zombiesAlive,
+    zombiesPlanned: state.zombiesPlanned
+  }
+}
+
+function getDebugLobbyPlayer(): LobbyPlayer | null {
+  const address = getLocalAddress()
+  if (!address) return null
+  return {
+    address,
+    displayName: `${address.slice(0, 6)}...${address.slice(-4)}`
+  }
+}
+
+function resetDebugMatchState(): void {
+  const runtime = ensureDebugMatchRuntimeState()
+  runtime.isRunning = false
+  runtime.waveNumber = 0
+  runtime.cyclePhase = WaveCyclePhase.ACTIVE
+  runtime.serverNowMs = Date.now()
+  runtime.phaseEndTimeMs = 0
+  runtime.startedByAddress = ''
+  runtime.zombiesAlive = 0
+  runtime.zombiesPlanned = 0
+}
+
+function debugJoinLobbyOnly(): void {
+  const player = getDebugLobbyPlayer()
+  if (!player) return
+
+  const lobby = ensureDebugLobbyState()
+  if (!lobby.players.some((entry) => entry.address === player.address)) {
+    lobby.players = [...lobby.players, player]
+  }
+  if (!lobby.hostAddress) {
+    lobby.hostAddress = player.address
+  }
+  latestLobbyEvent = `${player.displayName} joined debug lobby`
+  latestLobbyEventType = 'join'
+  latestLobbyEventAtMs = Date.now()
+  console.log(`[LobbyClientDebug] joined lobby as ${player.address}`)
+}
+
+function debugCreateMatch(): void {
+  const player = getDebugLobbyPlayer()
+  if (!player) return
+
+  debugJoinLobbyOnly()
+  const lobby = ensureDebugLobbyState()
+  if (lobby.phase === LobbyPhase.MATCH_CREATED) return
+
+  lobby.phase = LobbyPhase.MATCH_CREATED
+  lobby.matchId = `${DEBUG_MATCH_ID_PREFIX}${Date.now()}`
+  lobby.arenaPlayers = [...lobby.players]
+  lobby.countdownEndTimeMs = 0
+  lobby.arenaIntroEndTimeMs = 0
+  localReadyForMatch = false
+  resetDebugMatchState()
+  latestLobbyEvent = `Debug match created (${lobby.matchId})`
+  latestLobbyEventType = 'match_created'
+  latestLobbyEventAtMs = Date.now()
+  console.log(`[LobbyClientDebug] match created by ${player.address}`)
+}
+
+function debugCreateMatchAndJoin(): void {
+  debugCreateMatch()
+}
+
+function debugStartGameManual(): void {
+  const player = getDebugLobbyPlayer()
+  if (!player) return
+
+  debugCreateMatchAndJoin()
+  const lobby = ensureDebugLobbyState()
+  const runtime = ensureDebugMatchRuntimeState()
+  if (runtime.isRunning || lobby.countdownEndTimeMs > 0 || lobby.arenaIntroEndTimeMs > 0) return
+
+  lobby.countdownEndTimeMs = getServerTime() + LOCAL_AUTH_DEBUG_AUTO_TELEPORT_COUNTDOWN_SECONDS * 1000
+  latestLobbyEvent = 'Debug auto-teleport countdown started'
+  latestLobbyEventType = 'countdown'
+  latestLobbyEventAtMs = Date.now()
+  console.log(`[LobbyClientDebug] countdown started for ${player.address}`)
+}
+
+function debugLeaveLobby(): void {
+  const lobby = ensureDebugLobbyState()
+  lobby.phase = LobbyPhase.LOBBY
+  lobby.matchId = ''
+  lobby.hostAddress = ''
+  lobby.players = []
+  lobby.arenaPlayers = []
+  lobby.countdownEndTimeMs = 0
+  lobby.arenaIntroEndTimeMs = 0
+  localReadyForMatch = false
+  resetDebugMatchState()
+  latestLobbyEvent = 'Debug left lobby'
+  latestLobbyEventType = 'lobby'
+  latestLobbyEventAtMs = Date.now()
+  console.log('[LobbyClientDebug] left lobby without teleport')
+}
+
 export function getLobbyState(): LobbyStateSnapshot | null {
+  if (localAuthDebugActive) {
+    const state = ensureDebugLobbyState()
+    const localAddress = getLocalAddress()
+    const isInArenaRoster = !!localAddress && state.arenaPlayers.some((p) => p.address === localAddress)
+    if (state.phase !== LobbyPhase.MATCH_CREATED || !isInArenaRoster) {
+      localReadyForMatch = false
+    }
+    return cloneLobbyState(state)
+  }
+
   for (const [entity] of engine.getEntitiesWith(LobbyStateComponent)) {
     const state = LobbyStateComponent.get(entity)
     const localAddress = getLocalAddress()
     const isInArenaRoster = !!localAddress && state.arenaPlayers.some((p) => p.address === localAddress)
-    if (state.phase !== 'match_created' || !isInArenaRoster) {
+    if (state.phase !== LobbyPhase.MATCH_CREATED || !isInArenaRoster) {
       localReadyForMatch = false
     }
     return {
@@ -250,6 +570,10 @@ export function getLobbyState(): LobbyStateSnapshot | null {
 }
 
 export function getMatchRuntimeState(): MatchRuntimeSnapshot | null {
+  if (localAuthDebugActive) {
+    return cloneMatchRuntimeState(ensureDebugMatchRuntimeState())
+  }
+
   for (const [entity] of engine.getEntitiesWith(MatchRuntimeStateComponent)) {
     const state = MatchRuntimeStateComponent.get(entity)
     return {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -148,6 +148,10 @@ export const uiMenu = () => {
     lobbyState?.arenaIntroEndTimeMs && lobbyState.arenaIntroEndTimeMs > timerNowMs
       ? Math.max(0, Math.ceil((lobbyState.arenaIntroEndTimeMs - timerNowMs) / 1000))
       : 0
+  const startCountdownSeconds =
+    lobbyState?.countdownEndTimeMs && lobbyState.countdownEndTimeMs > timerNowMs
+      ? Math.max(0, Math.ceil((lobbyState.countdownEndTimeMs - timerNowMs) / 1000))
+      : 0
   const phaseRemainingSeconds = matchRuntime ? Math.max(0, Math.ceil((matchRuntime.phaseEndTimeMs - timerNowMs) / 1000)) : 0
   const showGameOverOverlay = shouldShowGameOverOverlay()
   const countdownLabel = getWaveCountdownLabel()
@@ -157,10 +161,9 @@ export const uiMenu = () => {
   const showCenteredOverlay = (!isIdle || playerDead) && !inMatchContext
   const showArenaIntroOverlay = inMatchContext && localReadyForMatch && !matchRuntime?.isRunning
   const isInZone = !!localAddress && !!lobbyState?.players.find((p) => p.address === localAddress)
-  const countdownOrIntroActive =
-    ((lobbyState?.countdownEndTimeMs ?? 0) > timerNowMs) ||
-    ((lobbyState?.arenaIntroEndTimeMs ?? 0) > timerNowMs)
-  const showStartGameButton = isInZone && !countdownOrIntroActive && !(matchRuntime?.isRunning)
+  const isStartGameButtonLocked = startCountdownSeconds > 0
+  const startGameButtonLabel = isStartGameButtonLocked ? `STARTING IN ${startCountdownSeconds}` : 'START GAME'
+  const showStartGameButton = isInZone && !localReadyForMatch && arenaIntroSeconds <= 0 && !(matchRuntime?.isRunning)
 
   const showZcCounter = showGameplayHud
   const brickTargetModeActive = isBrickTargetModeActive()
@@ -605,24 +608,30 @@ export const uiMenu = () => {
         >
           <UiEntity
             uiTransform={{
-              width: 260,
+              width: 320,
               height: 64,
               alignItems: 'center',
               justifyContent: 'center',
               borderRadius: 8
             }}
-            uiBackground={{ color: Color4.create(0.1, 0.7, 0.25, 0.92) }}
-            onMouseDown={() => {
-              beginUiPointerCapture()
-              sendStartGameManual()
+            uiBackground={{
+              color: isStartGameButtonLocked ? Color4.create(0.22, 0.46, 0.28, 0.92) : Color4.create(0.1, 0.7, 0.25, 0.92)
             }}
+            onMouseDown={
+              isStartGameButtonLocked
+                ? undefined
+                : () => {
+                    beginUiPointerCapture()
+                    sendStartGameManual()
+                  }
+            }
             onMouseUp={endUiPointerCapture}
           >
             <UiEntity
               uiTransform={{ width: '100%', height: '100%', alignItems: 'center', justifyContent: 'center' }}
               uiText={{
-                value: 'START GAME',
-                fontSize: 28,
+                value: startGameButtonLabel,
+                fontSize: 24,
                 color: Color4.White(),
                 textAlign: 'middle-center'
               }}


### PR DESCRIPTION
Moves the match countdown from the 3D world panel into the HUD start button, keeps the button locked while counting down, prevents the start button from flashing after arena teleport, and adds a lightweight local preview fallback to simulate authoritative lobby flow when LiveKit/server messaging is broken.

Closes #185 