### PR TITLE
Fix isometric camera and auto-fire persisting in lobby

### DIFF
--- a/src/multiplayer/lobbyClient.ts
+++ b/src/multiplayer/lobbyClient.ts
@@ -42,6 +42,8 @@ function resetLocalMatchUiState(): void {
   lastTeamWipeAffectedLocalPlayer = false
   playerCombatStateByAddress.clear()
   latestLobbyEventType = ''
+  setIsoViewEnabled(false)
+  setAutoFireEnabled(false)
   setLocalAvatarHidden(false)
   resetToIdle()
   resetArenaWeaponProgress()


### PR DESCRIPTION
## Summary
Resets isometric camera and auto-fire settings when returning to the lobby after an arena match.

## Changes
- Added `setIsoViewEnabled(false)` to `resetLocalMatchUiState()` to disable isometric camera when exiting arena
- Added `setAutoFireEnabled(false)` to reset auto-fire state as well

## Problem
After entering the arena (where isometric camera and auto-fire are enabled by default), these settings would persist when the player returned to the lobby, creating a jarring UX.

## Solution
Explicitly reset both camera mode and auto-fire state in the `resetLocalMatchUiState()` function, which is called when transitioning back to the lobby.

Closes #215

---
Requested by Agustin Carriso via Slack