### PR TITLE
Fix textShapes angle for isometric view

### DIFF
--- a/src/gameplayInput.ts
+++ b/src/gameplayInput.ts
@@ -1,13 +1,19 @@
 import { engine, inputSystem, InputAction } from '@dcl/sdk/ecs'
 import { ZombieComponent } from './zombie'
 import { isPlayerDead } from './playerHealth'
+import {
+  isTopViewEnabled,
+  toggleTopView,
+  isIsoViewEnabled,
+  toggleIsoView
+} from './viewModes'
+
+export { isTopViewEnabled, setTopViewEnabled, isIsoViewEnabled, setIsoViewEnabled } from './viewModes'
 
 let uiPointerCaptureActive = false
 let autoFireEnabled = false
 let prevSecondaryPressed = false
-let topViewEnabled = false
 let prevAction3Pressed = false
-let isoViewEnabled = false
 let prevAction4Pressed = false
 
 function syncUiPointerCapture(): void {
@@ -44,37 +50,18 @@ export function updateAutoFireToggle(): void {
   prevSecondaryPressed = isPressed
 }
 
-export function isTopViewEnabled(): boolean {
-  return topViewEnabled
-}
-
-export function setTopViewEnabled(value: boolean): void {
-  topViewEnabled = value
-}
-
 export function updateTopViewToggle(): void {
   const isPressed = inputSystem.isPressed(InputAction.IA_ACTION_3)
   if (isPressed && !prevAction3Pressed) {
-    topViewEnabled = !topViewEnabled
-    if (topViewEnabled) isoViewEnabled = false
+    toggleTopView()
   }
   prevAction3Pressed = isPressed
-}
-
-export function isIsoViewEnabled(): boolean {
-  return isoViewEnabled
-}
-
-export function setIsoViewEnabled(value: boolean): void {
-  isoViewEnabled = value
-  if (value) topViewEnabled = false
 }
 
 export function updateIsoViewToggle(): void {
   const isPressed = inputSystem.isPressed(InputAction.IA_ACTION_4)
   if (isPressed && !prevAction4Pressed) {
-    isoViewEnabled = !isoViewEnabled
-    if (isoViewEnabled) topViewEnabled = false
+    toggleIsoView()
   }
   prevAction4Pressed = isPressed
 }

--- a/src/viewModes.ts
+++ b/src/viewModes.ts
@@ -1,0 +1,28 @@
+let topViewEnabled = false
+let isoViewEnabled = false
+
+export function isTopViewEnabled(): boolean {
+  return topViewEnabled
+}
+
+export function setTopViewEnabled(value: boolean): void {
+  topViewEnabled = value
+  if (value) isoViewEnabled = false
+}
+
+export function toggleTopView(): void {
+  setTopViewEnabled(!topViewEnabled)
+}
+
+export function isIsoViewEnabled(): boolean {
+  return isoViewEnabled
+}
+
+export function setIsoViewEnabled(value: boolean): void {
+  isoViewEnabled = value
+  if (value) topViewEnabled = false
+}
+
+export function toggleIsoView(): void {
+  setIsoViewEnabled(!isoViewEnabled)
+}

--- a/src/zombie.ts
+++ b/src/zombie.ts
@@ -30,6 +30,7 @@ import {
   getRageShieldRadius,
   isRaging
 } from './rageEffect'
+import { isIsoViewEnabled } from './viewModes'
 
 // Animation clip names from Zombie.glb
 const ANIM_ZOMBIE_UP = 'ZombieUP'
@@ -149,7 +150,8 @@ const REWARD_TEXT_RISE_SPEED = 1.15
 const REWARD_TEXT_BASE_COLOR = Color4.create(0.0, 1.0, 0.92, 1)
 const REWARD_TEXT_Y_OFFSET = 2.7
 const REWARD_TEXT_SCALE = 0.9
-const REWARD_TEXT_FACING_FIX = Quaternion.fromEulerDegrees(0, 180, 0)
+const REWARD_TEXT_YAW_FIX_DEG = 180
+const REWARD_TEXT_ISO_TILT_DEG = 45
 const REWARD_TEXT_POOL_SIZE = 24
 
 const rewardTextPool: Entity[] = []
@@ -798,6 +800,7 @@ export function explosionVfxSystem(): void {
 
 export function rewardTextSystem(dt: number) {
   const cameraPos = Transform.has(engine.CameraEntity) ? Transform.get(engine.CameraEntity).position : null
+  const pitchDeg = isIsoViewEnabled() ? REWARD_TEXT_ISO_TILT_DEG : 0
   for (const [entity, reward, transform] of engine.getEntitiesWith(RewardTextComponent, Transform, TextShape)) {
     if (!reward.active) continue
 
@@ -820,8 +823,8 @@ export function rewardTextSystem(dt: number) {
       toCam.y = 0
       const lenXZ = Math.sqrt(toCam.x * toCam.x + toCam.z * toCam.z)
       if (lenXZ > 0.001) {
-        const faceCam = Quaternion.lookRotation(Vector3.normalize(toCam))
-        mutableTransform.rotation = Quaternion.multiply(REWARD_TEXT_FACING_FIX, faceCam)
+        const yawDeg = (Math.atan2(toCam.x, toCam.z) * 180) / Math.PI
+        mutableTransform.rotation = Quaternion.fromEulerDegrees(pitchDeg, yawDeg + REWARD_TEXT_YAW_FIX_DEG, 0)
       }
     }
 


### PR DESCRIPTION
## Summary
Tilts reward textShapes at 45° when isometric view is enabled for better visibility.

## Changes
- Created `viewModes.ts` module to centralize view mode state (top view, iso view)
- Refactored `gameplayInput.ts` to use centralized view mode functions
- Updated reward text system to apply 45° pitch rotation when in isometric view
- Maintains billboard behavior while adding iso-friendly tilt

## Testing
- Verify reward texts are readable in both normal and isometric camera modes
- Confirm top/iso view toggles still work correctly

Closes #222

---
Requested by Agustin Carriso via Slack