### PR TITLE
feat/weapon-tuning-lava-instant-damage

### DIFF
--- a/src/collectible.ts
+++ b/src/collectible.ts
@@ -23,6 +23,7 @@ const CollectibleComponent = engine.defineComponent('CollectibleComponent', {
 })
 
 const localCollectibleById = new Map<string, Entity>()
+const predictedPickupIds = new Set<string>()
 let isInitialized = false
 
 function isLocalPlayerInCurrentMatch(): boolean {
@@ -68,9 +69,12 @@ function removeCollectibleById(collectibleId: string): void {
   if (!entity) return
   if (CollectibleComponent.has(entity)) engine.removeEntity(entity)
   localCollectibleById.delete(collectibleId)
+  predictedPickupIds.delete(collectibleId)
 }
 
 function clearAllCollectibles(): void {
+  for (const id of predictedPickupIds) addZombieCoins(-COINS_PER_KILL)
+  predictedPickupIds.clear()
   for (const id of [...localCollectibleById.keys()]) removeCollectibleById(id)
 }
 
@@ -92,14 +96,21 @@ export function initCollectibleClient(): void {
     const localAddress = getLocalAddress()
     if (entity && CollectibleComponent.has(entity) && localAddress && data.claimerAddress.toLowerCase() === localAddress) {
       const col = CollectibleComponent.get(entity)
-      const pos = { x: col.baseX, y: COLLECTIBLE_FLOAT_HEIGHT, z: col.baseZ }
-      addZombieCoins(COINS_PER_KILL)
-      spawnZcRewardTextAtPosition(Vector3.create(pos.x, pos.y, pos.z), COINS_PER_KILL)
+      if (!predictedPickupIds.has(data.collectibleId)) {
+        const pos = { x: col.baseX, y: COLLECTIBLE_FLOAT_HEIGHT, z: col.baseZ }
+        addZombieCoins(COINS_PER_KILL)
+        spawnZcRewardTextAtPosition(Vector3.create(pos.x, pos.y, pos.z), COINS_PER_KILL)
+      }
+    } else if (predictedPickupIds.has(data.collectibleId)) {
+      addZombieCoins(-COINS_PER_KILL)
     }
     removeCollectibleById(data.collectibleId)
   })
 
   room.onMessage('collectibleExpired', (data) => {
+    if (predictedPickupIds.has(data.collectibleId)) {
+      addZombieCoins(-COINS_PER_KILL)
+    }
     removeCollectibleById(data.collectibleId)
   })
 
@@ -110,7 +121,13 @@ export function initCollectibleClient(): void {
   room.onMessage('collectibleClaimRejected', (data: { collectibleId: string }) => {
     const entity = localCollectibleById.get(data.collectibleId)
     if (!entity || !CollectibleComponent.has(entity)) return
+    if (predictedPickupIds.delete(data.collectibleId)) {
+      addZombieCoins(-COINS_PER_KILL)
+    }
     CollectibleComponent.getMutable(entity).claimPending = false
+    if (Transform.has(entity)) {
+      Transform.getMutable(entity).scale = Vector3.One()
+    }
   })
 }
 
@@ -148,8 +165,17 @@ export function collectibleSystem(dt: number): void {
     if (dist > COLLECTIBLE_PICKUP_RADIUS) continue
 
     CollectibleComponent.getMutable(entity).claimPending = true
+    predictedPickupIds.add(col.collectibleId)
+    addZombieCoins(COINS_PER_KILL)
+    spawnZcRewardTextAtPosition(Vector3.create(col.baseX, COLLECTIBLE_FLOAT_HEIGHT, col.baseZ), COINS_PER_KILL)
+    t.scale = Vector3.Zero()
     void room.send('collectiblePickupRequest', { collectibleId: col.collectibleId })
   }
 
-  for (const id of toRemove) removeCollectibleById(id)
+  for (const id of toRemove) {
+    if (predictedPickupIds.has(id)) {
+      addZombieCoins(-COINS_PER_KILL)
+    }
+    removeCollectibleById(id)
+  }
 }

--- a/src/gun.ts
+++ b/src/gun.ts
@@ -28,7 +28,7 @@ import { getArenaWeaponModelPath, getArenaWeaponShootClip } from './shared/loado
 // Gun config - tweak these to your liking
 const ROUNDS_PER_SECOND = 2 // Manual fire rate: 1 shot every 0.5s
 const FIRE_RATE = 1 / ROUNDS_PER_SECOND // Seconds between shots (derived)
-const SHOOT_RANGE = 100
+const SHOOT_RANGE = 15
 const PROJECTILE_SPEED = 28 // Faster bullets make auto-aim feel more responsive
 const ZOMBIE_TARGET_HEIGHT = 0.9 // Meters above zombie feet to aim at (0.9 = chest level)
 const BULLET_MODEL_SRC = 'assets/scene/Models/bullets/Bullet.glb'
@@ -41,7 +41,7 @@ const MUZZLE_FLASH_OFFSET_MODEL_LOCAL = Vector3.create(0, 0, -0.08)
 // How long to freeze gun rotation after shooting (so bullet spawn looks correct). Tweak to match your shoot clip length.
 const GUN_ROTATION_SMOOTH_SPEED = 20
 // Bullet flies straight; remove after this distance from spawn (out of scene)
-const BULLET_MAX_DISTANCE = 48
+const BULLET_MAX_DISTANCE = 15
 const PROJECTILE_COLLIDER_SCALE_VALUE = 0.18
 const PROJECTILE_COLLIDER_SCALE = Vector3.create(
   PROJECTILE_COLLIDER_SCALE_VALUE,
@@ -50,17 +50,16 @@ const PROJECTILE_COLLIDER_SCALE = Vector3.create(
 )
 // Keep the gameplay collider small while rendering the GLB at a readable size.
 const PROJECTILE_VISUAL_LOCAL_SCALE_VALUE = 1 / PROJECTILE_COLLIDER_SCALE_VALUE
-const PROJECTILE_VISUAL_SHRINK_START_DISTANCE = 2.5
-const PROJECTILE_VISUAL_SHRINK_END_DISTANCE = 10
+const PROJECTILE_VISUAL_SHRINK_DISTANCE = 6
 const GUN_SYSTEM_PRIORITY_LAST = -1000
 const PROJECTILE_HIT_RADIUS = 1.15
 const PROJECTILE_HIT_RADIUS_SQ = PROJECTILE_HIT_RADIUS * PROJECTILE_HIT_RADIUS
 
 // Per-tier gun upgrade stats (matches UI display in lobbyStoreUi.tsx WEAPON_STATS)
 const GUN_UPGRADE_STATS: Record<number, { damage: number; fireRate: number }> = {
-  1: { damage: 1, fireRate: 0.40 },
-  2: { damage: 1, fireRate: 0.35 },
-  3: { damage: 2, fireRate: 0.30 }
+  1: { damage: 1, fireRate: 0.44 },
+  2: { damage: 1, fireRate: 0.38 },
+  3: { damage: 2, fireRate: 0.33 }
 }
 
 // Projectile: flies straight; hit detection is via TriggerArea on zombies (collider-based)
@@ -72,6 +71,7 @@ const ProjectileComponentSchema = {
   weaponType: Schemas.String,
   shotSeq: Schemas.Number,
   speed: Schemas.Number,
+  maxDistance: Schemas.Number,
   damage: Schemas.Number
 }
 export const ProjectileComponent = engine.defineComponent('ProjectileComponent', ProjectileComponentSchema)
@@ -201,7 +201,8 @@ export function spawnProjectileEntity(
   weaponType: WeaponProjectileType,
   shotSeq: number,
   damage: number = 1,
-  speed: number = PROJECTILE_SPEED
+  speed: number = PROJECTILE_SPEED,
+  maxDistance: number = BULLET_MAX_DISTANCE
 ): Entity {
   const projectile = engine.addEntity()
   Transform.create(projectile, {
@@ -235,6 +236,7 @@ export function spawnProjectileEntity(
     weaponType,
     shotSeq,
     speed,
+    maxDistance,
     damage
   })
 
@@ -245,12 +247,13 @@ export function spawnProjectileEntity(
   return projectile
 }
 
-function getProjectileVisualScaleFactor(traveled: number): number {
-  if (traveled <= PROJECTILE_VISUAL_SHRINK_START_DISTANCE) return 1
+function getProjectileVisualScaleFactor(traveled: number, maxDistance: number): number {
+  const shrinkStartDistance = Math.max(2.5, maxDistance - PROJECTILE_VISUAL_SHRINK_DISTANCE)
+  if (traveled <= shrinkStartDistance) return 1
   const shrinkT = Math.min(
     1,
-    (traveled - PROJECTILE_VISUAL_SHRINK_START_DISTANCE) /
-      (PROJECTILE_VISUAL_SHRINK_END_DISTANCE - PROJECTILE_VISUAL_SHRINK_START_DISTANCE)
+    (traveled - shrinkStartDistance) /
+      Math.max(0.01, maxDistance - shrinkStartDistance)
   )
   return 1 - shrinkT
 }
@@ -273,7 +276,7 @@ function spawnProjectile(
   } else {
     spawnMuzzleFlashVfx(spawnPos, gunWorldRot)
   }
-  spawnProjectileEntity(spawnPos, direction, canDamage, weaponType, shotSeq, damage, PROJECTILE_SPEED)
+  spawnProjectileEntity(spawnPos, direction, canDamage, weaponType, shotSeq, damage, PROJECTILE_SPEED, BULLET_MAX_DISTANCE)
   return direction
 }
 
@@ -334,7 +337,8 @@ function projectileSystem(dt: number) {
 
     // Remove if bullet went out of range (out of scene)
     const traveled = Vector3.distance(newPos, startPos)
-    if (traveled > BULLET_MAX_DISTANCE) {
+    const maxDistance = projData.maxDistance > 0 ? projData.maxDistance : BULLET_MAX_DISTANCE
+    if (traveled > maxDistance) {
       engine.removeEntityWithChildren(projectile)
       continue
     }
@@ -343,7 +347,7 @@ function projectileSystem(dt: number) {
     mutableTransform.position = newPos
 
     if (Transform.has(projData.visualEntity)) {
-      const scaleFactor = getProjectileVisualScaleFactor(traveled)
+      const scaleFactor = getProjectileVisualScaleFactor(traveled, maxDistance)
       if (scaleFactor <= 0) {
         engine.removeEntity(projData.visualEntity)
       } else {
@@ -437,6 +441,7 @@ export function gunSystem(dt: number) {
 
   const isTriggerHeld = isGameplayFireHeld()
   if (!isTriggerHeld) return
+  if (!nearestZombie) return
 
   shootTimer = 0
   playGunAnimation()

--- a/src/lavaHazard.ts
+++ b/src/lavaHazard.ts
@@ -4,6 +4,7 @@ import { room } from './shared/messages'
 import { getLobbyState, getLocalAddress, isLocalReadyForMatch } from './multiplayer/lobbyClient'
 import { LobbyPhase } from './shared/lobbySchemas'
 import { getServerTime } from './shared/timeSync'
+import { triggerPredictedDamageFeedback } from './playerHealth'
 import {
   LAVA_DAMAGE_INTERVAL_MS,
   LAVA_GRID_SIZE_X,
@@ -31,12 +32,14 @@ type LocalLavaZone = {
 }
 
 const HIDDEN_POSITION_Y = -3
+const LAVA_JUMP_CLEARANCE_Y = 0.9
 
 const localLavaZoneByKey = new Map<string, LocalLavaZone>()
 const localLavaTileKeyById = new Map<string, string>()
 let isLavaSyncInitialized = false
 let areLavaZonesInitialized = false
 let lastLavaDamageRequestAtMs = 0
+let lavaPlayerGroundY: number | null = null
 let sweepWarningStartAtMs = 0
 let sweepWarningEndAtMs = 0
 
@@ -118,6 +121,7 @@ function clearZoneState(zone: LocalLavaZone): void {
 
 function clearAllLavaHazards(): void {
   lastLavaDamageRequestAtMs = 0
+  lavaPlayerGroundY = null
   for (const zone of localLavaZoneByKey.values()) {
     clearZoneState(zone)
   }
@@ -241,6 +245,11 @@ export function lavaHazardSystem(): void {
   if (now - lastLavaDamageRequestAtMs < LAVA_DAMAGE_INTERVAL_MS) return
 
   const playerPosition = Transform.get(engine.PlayerEntity).position
+  if (lavaPlayerGroundY === null || playerPosition.y < lavaPlayerGroundY || playerPosition.y - lavaPlayerGroundY < 0.2) {
+    lavaPlayerGroundY = playerPosition.y
+  }
+  if (lavaPlayerGroundY !== null && playerPosition.y - lavaPlayerGroundY > LAVA_JUMP_CLEARANCE_Y) return
+
   const tileCoords = getLavaGridCoordsFromWorld(playerPosition.x, playerPosition.z)
   if (!tileCoords) return
 
@@ -249,5 +258,6 @@ export function lavaHazardSystem(): void {
   if (now < zone.activeAtMs || now >= zone.expiresAtMs) return
 
   lastLavaDamageRequestAtMs = now
+  triggerPredictedDamageFeedback(1)
   void room.send('lavaHazardDamageRequest', { lavaId: zone.lavaId })
 }

--- a/src/miniGun.ts
+++ b/src/miniGun.ts
@@ -31,7 +31,7 @@ import { getArenaWeaponModelPath, getArenaWeaponShootClip } from './shared/loado
 // Gun config - tweak these to your liking
 const ROUNDS_PER_SECOND = 6 // Minigun should feel like sustained pressure
 const FIRE_RATE = 1 / ROUNDS_PER_SECOND // Seconds between shots
-const SHOOT_RANGE = 100
+const SHOOT_RANGE = 15
 const PROJECTILE_SPEED = 32 // Fast tracers help the minigun read as high-pressure fire
 const ZOMBIE_TARGET_HEIGHT = 0.9 // Meters above zombie feet to aim at (0.9 = chest level)
 // Muzzle position in gun local space (x=right, y=up, z=forward) – matches GLB mesh so bullets spawn at barrel
@@ -39,7 +39,7 @@ const MUZZLE_OFFSET_GUN_LOCAL = Vector3.create(0.45, 1.15, 0.58)
 // Shorter freeze so rotation can update between shots (minigun fires every 0.2s; 0.4s would block rotation entirely)
 const GUN_ROTATION_SMOOTH_SPEED = 20
 // Bullet flies straight; remove after this distance from spawn (out of scene)
-const BULLET_MAX_DISTANCE = 40
+const BULLET_MAX_DISTANCE = 15
 const GUN_SYSTEM_PRIORITY_LAST = -1000
 
 let gunEntity: Entity | null = null
@@ -128,7 +128,7 @@ function spawnProjectile(
   } else {
     spawnMuzzleFlashVfx(spawnPos, gunWorldRot)
   }
-  spawnProjectileEntity(spawnPos, direction, canDamage, weaponType, shotSeq, 1, PROJECTILE_SPEED)
+  spawnProjectileEntity(spawnPos, direction, canDamage, weaponType, shotSeq, 1, PROJECTILE_SPEED, BULLET_MAX_DISTANCE)
   return direction
 }
 
@@ -249,6 +249,7 @@ export function miniGunSystem(dt: number) {
   if (shootTimer < effectiveFireRate) return
 
   if (!isTriggerHeld) return
+  if (!nearestZombie) return
 
   shootTimer = 0
   playGunAnimation()

--- a/src/playerHealth.ts
+++ b/src/playerHealth.ts
@@ -16,6 +16,8 @@ let diedAtMs = 0
 let damageOverlayTriggeredAtMs = 0
 let damageOverlayPeakAlpha = 0
 let hasReceivedAuthoritativeHealthState = false
+let predictedDamageFeedbackAmount = 0
+let predictedDamageFeedbackAtMs = 0
 
 /** Respawn position in scene (center of play area) */
 const RESPAWN_POSITION = Vector3.create(ARENA_CENTER.x, 0, ARENA_CENTER.z)
@@ -26,6 +28,7 @@ const DAMAGE_OVERLAY_FADE_OUT_MS = 560
 const DAMAGE_OVERLAY_BASE_ALPHA = 0.12
 const DAMAGE_OVERLAY_ALPHA_PER_HP = 0.05
 const DAMAGE_OVERLAY_MAX_ALPHA = 0.26
+const PREDICTED_DAMAGE_FEEDBACK_SUPPRESS_MS = 2500
 
 export function getPlayerHp(): number {
   return currentHp
@@ -77,6 +80,8 @@ export function resetPlayerHealthState(): void {
   damageOverlayTriggeredAtMs = 0
   damageOverlayPeakAlpha = 0
   hasReceivedAuthoritativeHealthState = false
+  predictedDamageFeedbackAmount = 0
+  predictedDamageFeedbackAtMs = 0
 }
 
 /** Full reset including lives — call when returning to lobby between runs. */
@@ -112,6 +117,16 @@ function triggerDamageOverlay(damageTaken: number, nowMs: number): void {
   )
 }
 
+export function triggerPredictedDamageFeedback(damageTaken: number): void {
+  if (isDead) return
+
+  const nowMs = getServerTime()
+  const normalizedDamage = Math.max(1, Math.floor(damageTaken))
+  predictedDamageFeedbackAmount += normalizedDamage
+  predictedDamageFeedbackAtMs = nowMs
+  triggerDamageOverlay(normalizedDamage, nowMs)
+}
+
 /** Respawn player: move to spawn, restore HP, clear death state. */
 export function respawnPlayer(): void {
   movePlayerTo({
@@ -129,7 +144,17 @@ export function applyAuthoritativeHealthState(hp: number, dead: boolean, nextRes
   const nextHp = Math.max(0, Math.min(MAX_HP, Math.floor(hp)))
 
   if (hasReceivedAuthoritativeHealthState && nextHp < previousHp) {
-    triggerDamageOverlay(previousHp - nextHp, nowMs)
+    const damageTaken = previousHp - nextHp
+    const shouldSuppressDuplicateFeedback =
+      predictedDamageFeedbackAmount > 0 &&
+      nowMs - predictedDamageFeedbackAtMs <= PREDICTED_DAMAGE_FEEDBACK_SUPPRESS_MS
+
+    if (shouldSuppressDuplicateFeedback) {
+      predictedDamageFeedbackAmount = Math.max(0, predictedDamageFeedbackAmount - damageTaken)
+      if (predictedDamageFeedbackAmount === 0) predictedDamageFeedbackAtMs = 0
+    } else {
+      triggerDamageOverlay(damageTaken, nowMs)
+    }
   }
 
   currentHp = nextHp

--- a/src/server/lavaHazardPatterns.ts
+++ b/src/server/lavaHazardPatterns.ts
@@ -295,9 +295,7 @@ function buildScatterPattern(waveNumber: number, waveStartAtMs: number, slot: Ev
 }
 
 function getStaticWarningDurationMs(waveNumber: number): number {
-  if (waveNumber >= 16) return 950
-  if (waveNumber >= 10) return 1100
-  return LAVA_WARNING_DURATION_MS
+  return 0
 }
 
 function getStaticActiveDurationMs(waveNumber: number): number {
@@ -424,10 +422,17 @@ function buildSafePocketPattern(waveNumber: number, waveStartAtMs: number, slot:
     getSafePocketActiveDurationMs(waveNumber),
     getStaticWarningDurationMs(waveNumber)
   )
-  const radiusX = waveNumber >= 18 ? randomFloat(2.4, 2.9) : waveNumber >= 16 ? randomFloat(2.8, 3.3) : randomFloat(3.2, 3.8)
-  const radiusZ = waveNumber >= 18 ? randomFloat(2.4, 2.9) : waveNumber >= 16 ? randomFloat(2.8, 3.3) : randomFloat(3.2, 3.8)
-  const marginX = Math.ceil(radiusX) + 1
-  const marginZ = Math.ceil(radiusZ) + 1
+  const maxRadius = Math.max(1.8, Math.min(LAVA_GRID_SIZE_X, LAVA_GRID_SIZE_Z) * 0.34)
+  const radiusX = Math.min(
+    waveNumber >= 18 ? randomFloat(2.4, 2.9) : waveNumber >= 16 ? randomFloat(2.8, 3.3) : randomFloat(3.2, 3.8),
+    maxRadius
+  )
+  const radiusZ = Math.min(
+    waveNumber >= 18 ? randomFloat(2.4, 2.9) : waveNumber >= 16 ? randomFloat(2.8, 3.3) : randomFloat(3.2, 3.8),
+    maxRadius
+  )
+  const marginX = Math.min(Math.ceil(radiusX) + 1, Math.floor(MAX_GRID_X / 2))
+  const marginZ = Math.min(Math.ceil(radiusZ) + 1, Math.floor(MAX_GRID_Z / 2))
 
   addInvertedSafeBlob(
     tiles,

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -98,9 +98,9 @@ const ZOMBIE_MAX_HP_BY_TYPE: Record<ZombieType, number> = {
   exploder: 15
 }
 const GUN_UPGRADE_FIRE_RATE_MS: Record<number, number> = {
-  1: 400,
-  2: 350,
-  3: 300
+  1: 440,
+  2: 380,
+  3: 330
 }
 const SPAWN_EDGE_BAND_WIDTH = 4.75
 const SPAWN_CENTER_SAFE_RADIUS = 8.5

--- a/src/shared/lavaHazardConfig.ts
+++ b/src/shared/lavaHazardConfig.ts
@@ -1,9 +1,8 @@
 import { Vector3 } from '@dcl/sdk/math'
 import {
-  ARENA_FLOOR_POSITION_X,
-  ARENA_FLOOR_POSITION_Z,
-  ARENA_FLOOR_WORLD_SIZE_X,
-  ARENA_FLOOR_WORLD_SIZE_Z
+  ARENA_MIN_X,
+  ARENA_MIN_Z,
+  ARENA_SIZE
 } from './arenaConfig'
 
 export const LAVA_MODEL_SRCS = [
@@ -14,10 +13,10 @@ export const LAVA_MODEL_SRCS = [
 
 export const LAVA_FIRST_WAVE = 1
 export const LAVA_ZONE_WORLD_SIZE = 4
-export const LAVA_WORLD_MIN_X = ARENA_FLOOR_POSITION_X
-export const LAVA_WORLD_MIN_Z = ARENA_FLOOR_POSITION_Z
-export const LAVA_WORLD_SIZE_X = ARENA_FLOOR_WORLD_SIZE_X
-export const LAVA_WORLD_SIZE_Z = ARENA_FLOOR_WORLD_SIZE_Z
+export const LAVA_WORLD_MIN_X = ARENA_MIN_X
+export const LAVA_WORLD_MIN_Z = ARENA_MIN_Z
+export const LAVA_WORLD_SIZE_X = ARENA_SIZE
+export const LAVA_WORLD_SIZE_Z = ARENA_SIZE
 export const LAVA_GRID_SIZE_X = Math.floor(LAVA_WORLD_SIZE_X / LAVA_ZONE_WORLD_SIZE)
 export const LAVA_GRID_SIZE_Z = Math.floor(LAVA_WORLD_SIZE_Z / LAVA_ZONE_WORLD_SIZE)
 export const LAVA_GRID_SIZE = Math.min(LAVA_GRID_SIZE_X, LAVA_GRID_SIZE_Z)
@@ -25,13 +24,13 @@ export const LAVA_TILE_SCALE_XZ = LAVA_ZONE_WORLD_SIZE
 export const LAVA_TILE_WARNING_SCALE_Y = 0.04
 export const LAVA_TILE_ACTIVE_SCALE_Y = 0.1
 export const LAVA_TILE_HIDDEN_SCALE_Y = 0.001
-export const LAVA_WARNING_DURATION_MS = 1400
+export const LAVA_WARNING_DURATION_MS = 0
 export const LAVA_DAMAGE_INTERVAL_MS = 2400
-export const LAVA_STATIC_ACTIVE_MS = 6500
-export const LAVA_SAFE_ZONE_ACTIVE_MS = 7500
+export const LAVA_STATIC_ACTIVE_MS = 12000
+export const LAVA_SAFE_ZONE_ACTIVE_MS = 12500
 export const LAVA_SWEEP_WARNING_MS = 850
 export const LAVA_SWEEP_STEP_INTERVAL_MS = 260
-export const LAVA_SWEEP_ACTIVE_MS = 1250
+export const LAVA_SWEEP_ACTIVE_MS = 2200
 
 export type LavaHazardTileState = {
   lavaId: string

--- a/src/shotGun.ts
+++ b/src/shotGun.ts
@@ -26,7 +26,7 @@ import { getArenaWeaponModelPath, getArenaWeaponShootClip } from './shared/loado
 // Gun config - tweak these to your liking
 const ROUNDS_PER_SECOND = 2.2 // Slightly quicker cadence keeps shotgun swaps snappy
 const FIRE_RATE = 1 / ROUNDS_PER_SECOND // Seconds between shots (derived)
-const SHOOT_RANGE = 100
+const SHOOT_RANGE = 15
 const PROJECTILE_SPEED = 26 // Slightly faster pellets reduce near-miss frustration
 const ZOMBIE_TARGET_HEIGHT = 0.9 // Meters above zombie feet to aim at (0.9 = chest level)
 // Muzzle position in gun local space (x=right, y=up, z=forward) – matches GLB mesh so bullets spawn at barrel
@@ -34,7 +34,7 @@ const MUZZLE_OFFSET_GUN_LOCAL = Vector3.create(0.45, 1.15, 0.58)
 // How long to freeze gun rotation after shooting (so bullet spawn looks correct). Tweak to match your shoot clip length.
 const GUN_ROTATION_SMOOTH_SPEED = 20
 // Bullet flies straight; remove after this distance from spawn (out of scene)
-const BULLET_MAX_DISTANCE = 40
+const BULLET_MAX_DISTANCE = 15
 const GUN_SYSTEM_PRIORITY_LAST = -1000
 
 let gunEntity: Entity | null = null
@@ -99,7 +99,7 @@ function spawnProjectile(
   ]
 
   for (const direction of directions) {
-    spawnProjectileEntity(spawnPos, direction, canDamage, weaponType, shotSeq, 1, PROJECTILE_SPEED)
+    spawnProjectileEntity(spawnPos, direction, canDamage, weaponType, shotSeq, 1, PROJECTILE_SPEED, BULLET_MAX_DISTANCE)
   }
   return baseDirection
 }
@@ -199,6 +199,7 @@ export function shotGunSystem(dt: number) {
 
   const isTriggerHeld = isGameplayFireHeld()
   if (!isTriggerHeld) return
+  if (!nearestZombie) return
 
   shootTimer = 0
   playGunAnimation()

--- a/src/zombie.ts
+++ b/src/zombie.ts
@@ -171,6 +171,7 @@ let reportPlayerDamageToServer: ((amount: number) => void) | null = null
 const lastRageShieldHitAtByZombieKey = new Map<string, number>()
 const explodedZombieIds = new Set<string>()
 const exploderWarningRingByZombie = new Map<Entity, Entity>()
+const predictedHitFeedbackAtByZombieId = new Map<string, number>()
 
 export function setZombieHitReporter(
   reporter: ((zombieId: string, damage: number, weaponType: ZombieHitWeaponType, shotSeq: number, posX: number, posY: number, posZ: number) => void) | null
@@ -505,8 +506,13 @@ const BLOOD_SPLAT_GLBS = [
   'assets/scene/Models/blood/Blood03.glb',
   'assets/scene/Models/blood/Blood04.glb'
 ]
-const BLOOD_SPLAT_LIFETIME = 15 // seconds before it disappears
-const BloodSplatComponent = engine.defineComponent('BloodSplatComponent', { removeAtTime: Schemas.Number })
+const BLOOD_SPLAT_MIN_LIFETIME = 3
+const BLOOD_SPLAT_MAX_LIFETIME = 5
+const BLOOD_SPLAT_FADE_OUT_SECONDS = 1.5
+const BloodSplatComponent = engine.defineComponent('BloodSplatComponent', {
+  spawnTime: Schemas.Number,
+  removeAtTime: Schemas.Number
+})
 
 function spawnBloodSplat(pos: Vector3): void {
   const src = BLOOD_SPLAT_GLBS[Math.floor(Math.random() * BLOOD_SPLAT_GLBS.length)]
@@ -522,7 +528,12 @@ function spawnBloodSplat(pos: Vector3): void {
     visibleMeshesCollisionMask: 0,
     invisibleMeshesCollisionMask: 0
   })
-  BloodSplatComponent.create(entity, { removeAtTime: getGameTime() + BLOOD_SPLAT_LIFETIME })
+  const lifetime = BLOOD_SPLAT_MIN_LIFETIME + Math.random() * (BLOOD_SPLAT_MAX_LIFETIME - BLOOD_SPLAT_MIN_LIFETIME)
+  const spawnTime = getGameTime()
+  BloodSplatComponent.create(entity, {
+    spawnTime,
+    removeAtTime: spawnTime + lifetime
+  })
 }
 
 /** Tick: remove expired blood splats */
@@ -530,7 +541,20 @@ export function bloodSplatSystem(): void {
   const now = getGameTime()
   const toRemove: Entity[] = []
   for (const [entity, splat] of engine.getEntitiesWith(BloodSplatComponent)) {
-    if (now >= splat.removeAtTime) toRemove.push(entity)
+    if (now >= splat.removeAtTime) {
+      toRemove.push(entity)
+      continue
+    }
+
+    if (!Transform.has(entity)) continue
+    const fadeStart = Math.max(splat.spawnTime, splat.removeAtTime - BLOOD_SPLAT_FADE_OUT_SECONDS)
+    if (now < fadeStart) continue
+
+    const fadeProgress = Math.max(0, Math.min(1, (now - fadeStart) / Math.max(0.01, splat.removeAtTime - fadeStart)))
+    const scale = Math.max(0.05, 1 - fadeProgress)
+    const transform = Transform.getMutable(entity)
+    transform.scale = Vector3.create(scale, scale, scale)
+    transform.position.y = 0.03 - fadeProgress * 0.03
   }
   for (const e of toRemove) engine.removeEntity(e)
 }
@@ -724,9 +748,15 @@ export function applyZombieHealthUpdateByNetworkId(zombieId: string, hp: number)
     const previousHp = mutableZombie.health
     mutableZombie.health = nextHp
     if (nextHp < previousHp) {
-      const pos = Transform.get(entity).position
-      const burstCenter = Vector3.create(pos.x, pos.y + 0.9, pos.z)
-      spawnBloodBurst(burstCenter, HIT_BURST_COUNT, HIT_BURST_SPEED, BLOOD_BURST_DURATION, HIT_BURST_SCALE)
+      const predictedFeedbackAt = predictedHitFeedbackAtByZombieId.get(zombieId) ?? 0
+      const shouldSuppressDuplicateFeedback = predictedFeedbackAt > 0 && getGameTime() - predictedFeedbackAt <= 0.75
+      if (shouldSuppressDuplicateFeedback) {
+        predictedHitFeedbackAtByZombieId.delete(zombieId)
+      } else {
+        const pos = Transform.get(entity).position
+        const burstCenter = Vector3.create(pos.x, pos.y + 0.9, pos.z)
+        spawnBloodBurst(burstCenter, HIT_BURST_COUNT, HIT_BURST_SPEED, BLOOD_BURST_DURATION, HIT_BURST_SCALE)
+      }
     }
     return true
   }
@@ -742,6 +772,13 @@ export function damageZombie(
   if (!ZombieComponent.has(entity)) return false
   const zombie = ZombieComponent.get(entity)
   if (zombie.networkId) {
+    if (Transform.has(entity)) {
+      const pos = Transform.get(entity).position
+      const burstCenter = Vector3.create(pos.x, pos.y + 0.9, pos.z)
+      spawnBloodBurst(burstCenter, HIT_BURST_COUNT, HIT_BURST_SPEED, BLOOD_BURST_DURATION, HIT_BURST_SCALE)
+      predictedHitFeedbackAtByZombieId.set(zombie.networkId, getGameTime())
+    }
+
     if (hitSource) {
       const pos = Transform.has(entity) ? Transform.get(entity).position : { x: 0, y: 0, z: 0 }
       reportServerZombieHit?.(zombie.networkId, amount, hitSource.weaponType, hitSource.shotSeq, pos.x, pos.y, pos.z)

--- a/src/zombieCoins.ts
+++ b/src/zombieCoins.ts
@@ -8,7 +8,7 @@ export function getZombieCoins(): number {
 }
 
 export function addZombieCoins(amount: number): void {
-  zombieCoins += amount
+  zombieCoins = Math.max(0, zombieCoins + amount)
 }
 
 /** Spend coins if player has enough. Returns true if spent, false if not enough. */


### PR DESCRIPTION
PR Summary:

### Weapon tuning, range reduction & instant lava damage
**Weapons**

- Reduced SHOOT_RANGE and BULLET_MAX_DISTANCE to 15m on all weapons (gun, shotgun, minigun) — bullets no longer travel across the full arena in isometric view
- Weapons no longer fire when no zombie is within range (if (!nearestZombie) return added to all weapon systems)
- Fire rates adjusted to be slightly faster than the previous Codex values but still slower than the original — roughly halved the slowdown delta across all tiers. Server-side GUN_UPGRADE_FIRE_RATE_MS updated to match

**Lava hazard**

- Removed warning phase: LAVA_WARNING_DURATION_MS set to 0 — lava tiles deal damage immediately on spawn
- getStaticWarningDurationMs() simplified to always return 0

**Client-side prediction**

- Optimistic coin pickup feedback — coins awarded immediately, reverted on server rejection
- Immediate blood burst on zombie hit before server confirmation
- Predicted damage overlay on lava hit
- Zombie coins clamped to minimum 0
- Lava damage skipped while player is airborne (jump clearance 0.9m)

Closes #243 