### PR TITLE
fix: lobby ui disappearing

### DIFF
--- a/src/lobbyWorldPanel.ts
+++ b/src/lobbyWorldPanel.ts
@@ -63,7 +63,6 @@ export class LobbyWorldPanel {
   private lastRenderedGameTextMode: GameTextMode | null = null
   private frozenPlayersText: string | null = null
   private hasFrozenPlayersTextThisMatch = false
-  private isLocalPlayerInsideTrigger = false
   private lastJoinRequestAtMs = 0
   private lastLeaveRequestAtMs = 0
 
@@ -126,13 +125,11 @@ export class LobbyWorldPanel {
     triggerAreaEventsSystem.onTriggerEnter(this.triggerEntity, (result) => {
       if (result.trigger?.entity !== engine.PlayerEntity) return
       console.log('[LobbyPanel] Player entered trigger area')
-      this.isLocalPlayerInsideTrigger = true
       localPlayerInsideLobbyTrigger = true
       this.requestLobbyJoinIfNeeded()
     })
     triggerAreaEventsSystem.onTriggerExit(this.triggerEntity, (result) => {
       if (result.trigger?.entity !== engine.PlayerEntity) return
-      this.isLocalPlayerInsideTrigger = false
       localPlayerInsideLobbyTrigger = false
       this.requestLobbyLeaveIfNeeded()
     })

--- a/src/lobbyWorldPanel.ts
+++ b/src/lobbyWorldPanel.ts
@@ -18,7 +18,7 @@ import {
   getLocalAddress,
   getMatchRuntimeState,
   isLocalReadyForMatch,
-  sendCreateMatchAndJoin,
+  sendJoinLobby,
   sendLeaveLobby
 } from './multiplayer/lobbyClient'
 import { getServerTime } from './shared/timeSync'
@@ -43,6 +43,7 @@ const HIDDEN_GAME_TEXT_ENTITY_NAMES = [
   EntityNames.NewGameText_glb_3,
   EntityNames.NewGameText_glb_4
 ]
+let localPlayerInsideLobbyTrigger = false
 
 type Entity = ReturnType<typeof engine.addEntity>
 type GameTextMode = 'new_game' | 'in_progress'
@@ -126,11 +127,13 @@ export class LobbyWorldPanel {
       if (result.trigger?.entity !== engine.PlayerEntity) return
       console.log('[LobbyPanel] Player entered trigger area')
       this.isLocalPlayerInsideTrigger = true
+      localPlayerInsideLobbyTrigger = true
       this.requestLobbyJoinIfNeeded()
     })
     triggerAreaEventsSystem.onTriggerExit(this.triggerEntity, (result) => {
       if (result.trigger?.entity !== engine.PlayerEntity) return
       this.isLocalPlayerInsideTrigger = false
+      localPlayerInsideLobbyTrigger = false
       this.requestLobbyLeaveIfNeeded()
     })
   }
@@ -178,7 +181,7 @@ export class LobbyWorldPanel {
     const nowMs = Date.now()
     if (nowMs - this.lastJoinRequestAtMs < LOBBY_REQUEST_COOLDOWN_MS) return
     this.lastJoinRequestAtMs = nowMs
-    sendCreateMatchAndJoin()
+    sendJoinLobby()
   }
 
   private requestLobbyLeaveIfNeeded(): void {
@@ -303,5 +306,10 @@ export class LobbyWorldPanel {
 }
 
 export function initLobbyWorldPanel(): LobbyWorldPanel {
+  localPlayerInsideLobbyTrigger = false
   return new LobbyWorldPanel()
+}
+
+export function isLocalPlayerInsideLobbyTrigger(): boolean {
+  return localPlayerInsideLobbyTrigger
 }

--- a/src/multiplayer/lobbyClient.ts
+++ b/src/multiplayer/lobbyClient.ts
@@ -202,14 +202,6 @@ export function sendCreateMatch(): void {
   void room.send('createMatch', {})
 }
 
-export function sendCreateMatchAndJoin(): void {
-  if (ensureLocalAuthDebugActive('createMatchAndJoin')) {
-    debugCreateMatchAndJoin()
-    return
-  }
-  void room.send('createMatchAndJoin', {})
-}
-
 export function sendStartGameManual(): void {
   if (ensureLocalAuthDebugActive('startGameManual')) {
     debugStartGameManual()
@@ -367,7 +359,7 @@ function hasAuthoritativeMatchRuntimeState(): boolean {
 }
 
 function ensureLocalAuthDebugActive(
-  reason: 'autoJoinLobbySystem' | 'joinLobby' | 'leaveLobby' | 'createMatch' | 'createMatchAndJoin' | 'startGameManual'
+  reason: 'autoJoinLobbySystem' | 'joinLobby' | 'leaveLobby' | 'createMatch' | 'startGameManual'
 ): boolean {
   if (localAuthDebugActive) return true
   if (!ENABLE_LOCAL_AUTH_DEBUG_IN_PREVIEW) return false
@@ -382,7 +374,6 @@ function ensureLocalAuthDebugActive(
     reason === 'joinLobby' ||
     reason === 'leaveLobby' ||
     reason === 'createMatch' ||
-    reason === 'createMatchAndJoin' ||
     reason === 'startGameManual'
   if (!graceElapsed && !shouldForceForAction) return false
 
@@ -508,15 +499,11 @@ function debugCreateMatch(): void {
   console.log(`[LobbyClientDebug] match created by ${player.address}`)
 }
 
-function debugCreateMatchAndJoin(): void {
-  debugCreateMatch()
-}
-
 function debugStartGameManual(): void {
   const player = getDebugLobbyPlayer()
   if (!player) return
 
-  debugCreateMatchAndJoin()
+  debugCreateMatch()
   const lobby = ensureDebugLobbyState()
   const runtime = ensureDebugMatchRuntimeState()
   if (runtime.isRunning || lobby.countdownEndTimeMs > 0 || lobby.arenaIntroEndTimeMs > 0) return

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -1673,33 +1673,6 @@ export function setupLobbyServer(): void {
     }
   })
 
-  room.onMessage('createMatchAndJoin', async (_data, context) => {
-    if (!context) return
-    if (!isPlayerInLobby(context.from) && isMatchJoinLocked()) {
-      logLobbyServerEvent(`JoinRejectedMatchLocked ${context.from.toLowerCase()}`)
-      await ensurePlayerProfileLoaded(context.from)
-      addPlayerToLobby(context.from)
-      void room.send('lobbyEvent', {
-        type: 'match_locked',
-        message: `${getPlayerDisplayName(context.from.toLowerCase())} can join the next match`
-      })
-      return
-    }
-    await ensurePlayerLoadedAndInLobby(context.from)
-    const state = getLobbyState()
-    if (state.phase !== LobbyPhase.MATCH_CREATED) {
-      createMatch(context.from)
-    }
-    sendPlayerHealthState(context.from)
-    sendArenaWeaponStatesTo(context.from)
-    sendPowerupStatesTo(context.from)
-    if (isPlayerInArena(context.from)) {
-      sendActivePotionsTo(context.from)
-      sendActiveLavaHazardsTo(context.from)
-      sendActiveCollectiblesTo(context.from)
-    }
-  })
-
   room.onMessage('playerArenaWeaponChanged', (data, context) => {
     if (!context) return
     const normalizedAddress = context.from.toLowerCase()

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -12,7 +12,6 @@ const LobbyMessages = {
     weaponId: Schemas.String
   }),
   createMatch: Schemas.Map({}),
-  createMatchAndJoin: Schemas.Map({}),
   startGameManual: Schemas.Map({}),
   waveSpawnPlan: Schemas.Map({
     waveNumber: Schemas.Number,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -45,6 +45,7 @@ import {
 import { getPlayerGold } from './loadoutState'
 import { OutlinedText } from './outlineComponent'
 import { LobbyStoreUi, openLobbyStore } from './lobbyStoreUi'
+import { isLocalPlayerInsideLobbyTrigger } from './lobbyWorldPanel'
 import {
   getLobbyState,
   getMatchRuntimeState,
@@ -175,7 +176,10 @@ export const uiMenu = () => {
   const isInArenaRoster = !!localAddress && !!lobbyState?.arenaPlayers.find((p) => p.address === localAddress)
   const matchRuntime = getMatchRuntimeState()
   const inMatchContext = lobbyState?.phase === LobbyPhase.MATCH_CREATED && isInArenaRoster
-  const isLobbyContext = !lobbyState || lobbyState.phase === LobbyPhase.LOBBY
+  const isLobbyContext =
+    !lobbyState ||
+    lobbyState.phase === LobbyPhase.LOBBY ||
+    (!isInArenaRoster && !isLocalReadyForMatch())
   const showGameplayHudDebug = DEBUG_SHOW_GAMEPLAY_HUD_IN_LOBBY && isLobbyContext
   const syncedZombiesLeft = matchRuntime?.zombiesAlive ?? 0
   const localReadyForMatch = isLocalReadyForMatch()
@@ -198,14 +202,20 @@ export const uiMenu = () => {
   const isIdle = state.phase === 'idle'
   const playerDead = isPlayerDead()
   const showDeathOverlay = !shouldSuppressDeathOverlayForTeamWipe() && !showGameOverOverlay && shouldShowDeathOverlay(timerNowMs)
-  const showCenteredOverlay = (!isIdle || playerDead) && !inMatchContext && !showGameplayHudDebug
+  const showCenteredOverlay = (!isIdle || playerDead) && !inMatchContext && !isLobbyContext && !showGameplayHudDebug
   const showArenaIntroOverlay = inMatchContext && localReadyForMatch && !matchRuntime?.isRunning
   const sweepWarning = showGameplayHud ? getSweepWarning(timerNowMs) : { active: false, remainingMs: 0 }
   const isInZone = !!localAddress && !!lobbyState?.players.find((p) => p.address === localAddress)
+  const isInsideLobbyTrigger = isLocalPlayerInsideLobbyTrigger()
   const isStartGameButtonLocked = startCountdownSeconds > 0
   const startGameButtonLabel = isStartGameButtonLocked ? `STARTING IN ${startCountdownSeconds}` : 'START GAME'
   const showStartGameButton =
-    isInZone && !localReadyForMatch && arenaIntroSeconds <= 0 && !(matchRuntime?.isRunning) && !showGameplayHudDebug
+    isInZone &&
+    isInsideLobbyTrigger &&
+    !localReadyForMatch &&
+    arenaIntroSeconds <= 0 &&
+    !(matchRuntime?.isRunning) &&
+    !showGameplayHudDebug
 
   const showZcCounter = showGameplayHud
   const brickTargetModeActive = isBrickTargetModeActive()


### PR DESCRIPTION
Fixed lobby UI scoping so non-participating players keep their lobby HUD when a room match starts, instead of inheriting the global match state. Also fixed the START GAME button to appear only for players physically standing inside the room trigger, preventing brief false prompts for players who remain in the lobby.

Closes #245 