### PR TITLE
ft: improve lava patterns

### DIFF
--- a/src/brick.ts
+++ b/src/brick.ts
@@ -75,14 +75,14 @@ export function spawnBrickAt(position: Vector3): Entity | null {
   try {
     GltfContainer.create(entity, {
       src: BRICK_GLB,
-      visibleMeshesCollisionMask: 0,
-      invisibleMeshesCollisionMask: 0
+      visibleMeshesCollisionMask: ColliderLayer.CL_PHYSICS,
+      invisibleMeshesCollisionMask: ColliderLayer.CL_PHYSICS
     })
   } catch {
     MeshRenderer.setBox(entity)
     Material.setPbrMaterial(entity, BRICK_BOX_MATERIAL)
+    MeshCollider.setBox(entity, ColliderLayer.CL_PHYSICS)
   }
-  MeshCollider.setBox(entity, ColliderLayer.CL_PHYSICS)
   BrickComponent.create(entity, { health: BRICK_HP, position: pos })
   syncEntity(entity, BRICK_SYNC_COMPONENT_IDS)
   return entity

--- a/src/lavaHazard.ts
+++ b/src/lavaHazard.ts
@@ -5,6 +5,7 @@ import { getLobbyState, getLocalAddress, isLocalReadyForMatch } from './multipla
 import { LobbyPhase } from './shared/lobbySchemas'
 import { getServerTime } from './shared/timeSync'
 import { triggerPredictedDamageFeedback } from './playerHealth'
+import { BRICK_RADIUS, getBricks } from './brick'
 import {
   LAVA_DAMAGE_INTERVAL_MS,
   LAVA_GRID_SIZE_X,
@@ -33,6 +34,7 @@ type LocalLavaZone = {
 
 const HIDDEN_POSITION_Y = -3
 const LAVA_JUMP_CLEARANCE_Y = 0.9
+const BRICK_SAFE_HEIGHT_Y = 0.35
 
 const localLavaZoneByKey = new Map<string, LocalLavaZone>()
 const localLavaTileKeyById = new Map<string, string>()
@@ -58,6 +60,17 @@ function getZoneModelVariant(gridX: number, gridZ: number): number {
 
 function getZoneRotationQuarterTurns(_gridX: number, _gridZ: number): number {
   return 0
+}
+
+function isPlayerStandingOnBrick(playerPosition: Vector3): boolean {
+  for (const { position } of getBricks()) {
+    const dx = playerPosition.x - position.x
+    const dz = playerPosition.z - position.z
+    if (dx * dx + dz * dz > BRICK_RADIUS * BRICK_RADIUS) continue
+    if (playerPosition.y < position.y + BRICK_SAFE_HEIGHT_Y) continue
+    return true
+  }
+  return false
 }
 
 function getZoneHiddenPosition(gridX: number, gridZ: number): Vector3 {
@@ -249,6 +262,7 @@ export function lavaHazardSystem(): void {
     lavaPlayerGroundY = playerPosition.y
   }
   if (lavaPlayerGroundY !== null && playerPosition.y - lavaPlayerGroundY > LAVA_JUMP_CLEARANCE_Y) return
+  if (isPlayerStandingOnBrick(playerPosition)) return
 
   const tileCoords = getLavaGridCoordsFromWorld(playerPosition.x, playerPosition.z)
   if (!tileCoords) return

--- a/src/server/lavaHazardPatterns.ts
+++ b/src/server/lavaHazardPatterns.ts
@@ -459,6 +459,7 @@ function addSweepPass(
 ): void {
   const laneStarts: number[] = []
   const maxStart = horizontal ? MAX_GRID_Z : MAX_GRID_X
+  const safeLaneIndexes = new Set(getSweepSafeLaneIndexes(horizontal))
 
   if (reversed) {
     for (let laneStart = maxStart - laneWidth + 1; laneStart >= 0; laneStart -= laneWidth) {
@@ -479,6 +480,7 @@ function addSweepPass(
 
     if (horizontal) {
       for (let gridX = 0; gridX < LAVA_GRID_SIZE_X; gridX += 1) {
+        if (safeLaneIndexes.has(gridX)) continue
         for (let widthOffset = 0; widthOffset < laneWidth; widthOffset += 1) {
           addTile(tiles, {
             gridX,
@@ -493,6 +495,7 @@ function addSweepPass(
     }
 
     for (let gridZ = 0; gridZ < LAVA_GRID_SIZE_Z; gridZ += 1) {
+      if (safeLaneIndexes.has(gridZ)) continue
       for (let widthOffset = 0; widthOffset < laneWidth; widthOffset += 1) {
         addTile(tiles, {
           gridX: laneStart + widthOffset,
@@ -504,6 +507,36 @@ function addSweepPass(
       }
     }
   })
+}
+
+function getSweepSafeLaneIndexes(horizontal: boolean): number[] {
+  const crossAxisSize = horizontal ? LAVA_GRID_SIZE_X : LAVA_GRID_SIZE_Z
+  const laneCount = crossAxisSize <= 4 ? 1 : Math.random() < 0.5 ? 1 : 2
+  const minLaneIndex = crossAxisSize <= 2 ? 0 : 1
+  const maxLaneIndex = crossAxisSize <= 2 ? crossAxisSize - 1 : crossAxisSize - 2
+
+  if (crossAxisSize <= 4) {
+    return [randomInt(minLaneIndex, maxLaneIndex)]
+  }
+
+  const selected = new Set<number>()
+  const minSpacing = crossAxisSize >= 7 ? 2 : 1
+  let attempts = 0
+
+  while (selected.size < laneCount && attempts < 20) {
+    const candidate = randomInt(minLaneIndex, maxLaneIndex)
+    const tooClose = Array.from(selected).some((existing) => Math.abs(existing - candidate) < minSpacing)
+    if (!tooClose) {
+      selected.add(candidate)
+    }
+    attempts += 1
+  }
+
+  while (selected.size < laneCount) {
+    selected.add(randomInt(minLaneIndex, maxLaneIndex))
+  }
+
+  return Array.from(selected).sort((a, b) => a - b)
 }
 
 function buildSweepPattern(waveNumber: number, waveStartAtMs: number, slot: EventSlot): TileCollection {


### PR DESCRIPTION
Improved lava sweep hazards so they are no longer unavoidable by carving 1-2 randomized safe corridors into each sweep pass. Added lava protection while the player is standing on top of a brick, and updated brick spawning to use the GLB’s built-in collision instead of forcing a manual box collider. Also removed the temporary early-wave lava debug override and restored the original early-wave hazard plan.

Closes #229 