### PR TITLE
fix: gun entity cycle

### DIFF
--- a/src/gun.ts
+++ b/src/gun.ts
@@ -573,16 +573,8 @@ export function gunSystem(dt: number) {
   const isInArena = isLocalPlayerInArena()
   const shouldTrackGun = !isPlayerDead() && isInArena && getCurrentWeapon() === 'gun'
 
-  if (!shouldTrackGun) {
-    if (gunEntity) destroyGun()
-    return
-  }
-
-  if (!gunEntity) {
-    createGun()
-  }
-
-  if (!gunEntity) return
+  // weaponManager owns gun spawn/despawn so the equipped upgrade level stays authoritative.
+  if (!shouldTrackGun || !gunEntity) return
 
   const playerTransform = Transform.get(engine.PlayerEntity)
   const gunWorldPos = Vector3.add(


### PR DESCRIPTION
Fix gun upgrade visuals being reset to tier 1 on local respawn/recreation.

gunSystem was recreating the pistol independently with createGun() and no upgrade level, which could override the equipped loadout visual and show the default green/basic gun even when the player owned and had equipped the gold tier. This change makes weaponManager the single authority for gun spawn/despawn so the equipped upgrade level remains consistent locally and in arena play.

Closes #251 