### PR TITLE
ft: hide unused npc

### DIFF
--- a/src/lobbyStore.ts
+++ b/src/lobbyStore.ts
@@ -13,6 +13,7 @@ type Entity = ReturnType<typeof engine.addEntity>
 type LobbyNpcConfig = {
   npcName: EntityNames
   clickName: EntityNames
+  hidden?: boolean
   hoverText?: string
   onClick?: () => void
 }
@@ -27,7 +28,8 @@ const LOBBY_NPC_CONFIGS: LobbyNpcConfig[] = [
   },
   {
     npcName: EntityNames.npcs02_glb,
-    clickName: EntityNames.npc_collider_2
+    clickName: EntityNames.npc_collider_2,
+    hidden: true
   }
 ]
 
@@ -65,6 +67,10 @@ function setupNpcClickHandler(config: LobbyNpcConfig, npcEntity: Entity, clickEn
   )
 }
 
+function hideNpc(clickEntity: Entity): void {
+  engine.removeEntityWithChildren(clickEntity)
+}
+
 export function initLobbyStore(): void {
   const pending = new Set(LOBBY_NPC_CONFIGS.map((config) => config.npcName))
   const systemName = 'lobby-store-npc-init-system'
@@ -76,7 +82,11 @@ export function initLobbyStore(): void {
       const clickEntity = findSceneEntity(config.clickName)
       if (!npcEntity || !clickEntity) continue
 
-      setupNpcClickHandler(config, npcEntity, clickEntity)
+      if (config.hidden) {
+        hideNpc(clickEntity)
+      } else {
+        setupNpcClickHandler(config, npcEntity, clickEntity)
+      }
       pending.delete(config.npcName)
     }
 

--- a/src/lobbyStore.ts
+++ b/src/lobbyStore.ts
@@ -67,7 +67,8 @@ function setupNpcClickHandler(config: LobbyNpcConfig, npcEntity: Entity, clickEn
   )
 }
 
-function hideNpc(clickEntity: Entity): void {
+function hideNpc(npcEntity: Entity, clickEntity: Entity): void {
+  engine.removeEntityWithChildren(npcEntity)
   engine.removeEntityWithChildren(clickEntity)
 }
 
@@ -83,7 +84,7 @@ export function initLobbyStore(): void {
       if (!npcEntity || !clickEntity) continue
 
       if (config.hidden) {
-        hideNpc(clickEntity)
+        hideNpc(npcEntity, clickEntity)
       } else {
         setupNpcClickHandler(config, npcEntity, clickEntity)
       }


### PR DESCRIPTION
Hide unused lobby NPC
Removes the unused non-shop NPC from the lobby by hiding its entity on init. Keeps the shop NPC unchanged.

Closes #253 