### PR TITLE
fix: block iso cameras at lobby

### DIFF
--- a/src/gameplayInput.ts
+++ b/src/gameplayInput.ts
@@ -12,6 +12,7 @@ export { isTopViewEnabled, setTopViewEnabled, isIsoViewEnabled, setIsoViewEnable
 
 let uiPointerCaptureActive = false
 let autoFireEnabled = false
+let cameraModeToggleEnabled = false
 let prevSecondaryPressed = false
 let prevAction3Pressed = false
 let prevAction4Pressed = false
@@ -42,6 +43,10 @@ export function setAutoFireEnabled(value: boolean): void {
   autoFireEnabled = value
 }
 
+export function setCameraModeToggleEnabled(value: boolean): void {
+  cameraModeToggleEnabled = value
+}
+
 export function updateAutoFireToggle(): void {
   const isPressed = inputSystem.isPressed(InputAction.IA_SECONDARY)
   if (isPressed && !prevSecondaryPressed) {
@@ -52,6 +57,10 @@ export function updateAutoFireToggle(): void {
 
 export function updateTopViewToggle(): void {
   const isPressed = inputSystem.isPressed(InputAction.IA_ACTION_3)
+  if (!cameraModeToggleEnabled) {
+    prevAction3Pressed = isPressed
+    return
+  }
   if (isPressed && !prevAction3Pressed) {
     toggleTopView()
   }
@@ -60,6 +69,10 @@ export function updateTopViewToggle(): void {
 
 export function updateIsoViewToggle(): void {
   const isPressed = inputSystem.isPressed(InputAction.IA_ACTION_4)
+  if (!cameraModeToggleEnabled) {
+    prevAction4Pressed = isPressed
+    return
+  }
   if (isPressed && !prevAction4Pressed) {
     toggleIsoView()
   }

--- a/src/multiplayer/lobbyClient.ts
+++ b/src/multiplayer/lobbyClient.ts
@@ -15,7 +15,7 @@ import { WAVE_ACTIVE_SECONDS, WAVE_REST_SECONDS } from '../shared/matchConfig'
 import { getCurrentRoomId as getRuntimeRoomId, setCurrentRoomId } from '../roomRuntime'
 import { DEFAULT_ROOM_ID, RoomId, getArenaRoomConfig, isRoomId } from '../shared/roomConfig'
 import { getServerTime } from '../shared/timeSync'
-import { setIsoViewEnabled, setAutoFireEnabled } from '../gameplayInput'
+import { setIsoViewEnabled, setTopViewEnabled, setAutoFireEnabled, setCameraModeToggleEnabled } from '../gameplayInput'
 
 let latestLobbyEvent = ''
 let latestLobbyEventType = ''
@@ -55,6 +55,8 @@ function resetLocalMatchUiState(): void {
   playerMatchKillsByAddress.clear()
   playerMatchZcByAddress.clear()
   latestLobbyEventType = ''
+  setCameraModeToggleEnabled(false)
+  setTopViewEnabled(false)
   setIsoViewEnabled(false)
   setAutoFireEnabled(false)
   setLocalAvatarHidden(false)
@@ -204,6 +206,7 @@ export function setupLobbyClient(): void {
     const localAddress = getLocalAddress()
     if (!localAddress || !data.addresses.includes(localAddress)) return
     localReadyForMatch = true
+    setCameraModeToggleEnabled(true)
     setIsoViewEnabled(true)
     setAutoFireEnabled(true)
     movePlayerTo({
@@ -222,21 +225,12 @@ export function setupLobbyClient(): void {
   room.onMessage('lobbyReturnTeleport', (data) => {
     const localAddress = getLocalAddress()
     if (!localAddress || !data.addresses.includes(localAddress)) return
-    setIsoViewEnabled(false)
-    setAutoFireEnabled(false)
-    setLocalAvatarHidden(false)
-    resetDeathAnimationState()
     resetLocalMatchUiState()
     movePlayerTo({
       newRelativePosition: {
         x: data.positionX,
         y: data.positionY,
         z: data.positionZ
-      },
-      cameraTarget: {
-        x: data.lookAtX,
-        y: data.lookAtY,
-        z: data.lookAtZ
       }
     })
   })

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -62,7 +62,7 @@ import {
   sendStartGameManual
 } from './multiplayer/lobbyClient'
 import { LobbyPhase } from './shared/lobbySchemas'
-import { LOBBY_RETURN_LOOK_AT, LOBBY_RETURN_POSITION } from './shared/roomConfig'
+import { LOBBY_RETURN_POSITION } from './shared/roomConfig'
 import { MATCH_MAX_PLAYERS } from './shared/matchConfig'
 import { getServerTime } from './shared/timeSync'
 
@@ -1352,8 +1352,7 @@ const teamPanelNameWidth = isMobileRuntime ? 100 : 120
               beginUiPointerCapture()
               sendLeaveLobby()
               movePlayerTo({
-                newRelativePosition: LOBBY_RETURN_POSITION,
-                cameraTarget: LOBBY_RETURN_LOOK_AT
+                newRelativePosition: LOBBY_RETURN_POSITION
               })
             }}
             onMouseUp={endUiPointerCapture}


### PR DESCRIPTION
Restricted camera mode toggles so they only work during active matches and no longer affect the player while in the lobby.

Previously, the 1 and 2 camera shortcuts could still toggle forced views outside gameplay, and returning from a match could leave the player with a forced camera orientation. This change disables camera mode hotkeys in lobby/non-match contexts, resets both top-view and iso-view state when leaving a run, and removes forced lobby camera targeting on match exit and Back to Lobby.

Result: players always return to the lobby with the normal free camera, and lobby camera controls are no longer overridden by gameplay hotkeys.

Closes #268 