### PR TITLE
fix: Player body persists when dying while running

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,8 @@ import { initWeaponLifecycleSystem } from './weaponManager'
 import {
   isPlayerDead,
   getRespawnDelay,
-  respawnPlayer
+  respawnPlayer,
+  initPlayerDeathMovementLockSystem
 } from './playerHealth'
 import { getGameTime } from './zombie'
 import { rageEffectSystem } from './rageEffect'
@@ -359,6 +360,7 @@ export function main() {
   engine.addSystem(collectibleSystem)
   engine.addSystem(lavaHazardSystem)
   initDeathAnimationSystem()
+  initPlayerDeathMovementLockSystem()
   // Authoritative match waves (30s active / 10s rest)
   initMatchWaveClientSystem()
 

--- a/src/playerHealth.ts
+++ b/src/playerHealth.ts
@@ -27,6 +27,10 @@ const DAMAGE_OVERLAY_BASE_ALPHA = 0.12
 const DAMAGE_OVERLAY_ALPHA_PER_HP = 0.05
 const DAMAGE_OVERLAY_MAX_ALPHA = 0.26
 const PREDICTED_DAMAGE_FEEDBACK_SUPPRESS_MS = 2500
+const DEAD_MOVEMENT_LOCK_DISTANCE_SQ = 0.0025
+
+let deathMovementLockPosition: Vector3 | null = null
+let deathMovementLockSystemInitialized = false
 
 export function getPlayerHp(): number {
   return currentHp
@@ -73,6 +77,7 @@ export function resetPlayerHealthState(): void {
   currentHp = MAX_HP
   isDead = false
   respawnAtMs = 0
+  deathMovementLockPosition = null
   healGlowEndTime = 0
   diedAtMs = 0
   damageOverlayTriggeredAtMs = 0
@@ -125,6 +130,37 @@ export function triggerPredictedDamageFeedback(damageTaken: number): void {
   triggerDamageOverlay(normalizedDamage, nowMs)
 }
 
+function captureDeathMovementLockPosition(): void {
+  if (!Transform.has(engine.PlayerEntity)) return
+  const position = Transform.get(engine.PlayerEntity).position
+  deathMovementLockPosition = Vector3.create(position.x, position.y, position.z)
+}
+
+function deadMovementLockSystem(): void {
+  if (!isDead || !deathMovementLockPosition || !Transform.has(engine.PlayerEntity)) return
+
+  const currentPosition = Transform.get(engine.PlayerEntity).position
+  const dx = currentPosition.x - deathMovementLockPosition.x
+  const dy = currentPosition.y - deathMovementLockPosition.y
+  const dz = currentPosition.z - deathMovementLockPosition.z
+  const distanceSq = dx * dx + dy * dy + dz * dz
+  if (distanceSq <= DEAD_MOVEMENT_LOCK_DISTANCE_SQ) return
+
+  void movePlayerTo({
+    newRelativePosition: {
+      x: deathMovementLockPosition.x,
+      y: deathMovementLockPosition.y,
+      z: deathMovementLockPosition.z
+    }
+  })
+}
+
+export function initPlayerDeathMovementLockSystem(): void {
+  if (deathMovementLockSystemInitialized) return
+  deathMovementLockSystemInitialized = true
+  engine.addSystem(deadMovementLockSystem, undefined, 'player-death-movement-lock-system')
+}
+
 /** Respawn player: move to spawn, restore HP, clear death state. */
 export function respawnPlayer(): void {
   const roomConfig = getCurrentRoomConfig()
@@ -166,6 +202,7 @@ export function applyAuthoritativeHealthState(hp: number, dead: boolean, nextRes
 
   if (!wasDead && dead) {
     diedAtMs = nextRespawnAtMs > 0 ? nextRespawnAtMs - RESPAWN_DELAY * 1000 : nowMs
+    captureDeathMovementLockPosition()
   }
 
   if (wasDead && !isDead) {


### PR DESCRIPTION
Fixed the dead-player movement issue that could make the local avatar reappear after death.

Previously, the local avatar hide area stayed at the death position while the player could still drift or move, which allowed the avatar to leave the modifier area and become visible again. This change locks the local player to their death position while they are dead, keeping the existing avatar hide behavior stable until respawn or lobby return.

The movement lock is cleared automatically on respawn and on full match/lobby reset.

Closes #270 