### PR TITLE
fix/shop-ui-price-overflow-and-pointer-filter

### DIFF
--- a/src/lobbyStoreUi.tsx
+++ b/src/lobbyStoreUi.tsx
@@ -631,6 +631,7 @@ function UpgradeCard({ weapon, isLast }: { weapon: LoadoutWeaponDefinition; isLa
         justifyContent: 'center',
         padding: { left: scaleStoreSpacing(6), right: scaleStoreSpacing(6) },
         flexShrink: 0,
+        pointerFilter: 'block',
       }}
       onMouseDown={() => { selectedWeaponId = weapon.id }}
     >
@@ -1031,6 +1032,7 @@ function DetailPanel({ weapon, embedded = false }: { weapon: LoadoutWeaponDefini
       >
         {showOwnedLabel || !owned ? (
           <UiEntity
+            key={`price-badge-${weapon.id}`}
             uiTransform={{
               width: owned
                 ? Math.round(STORE_OWNED_SOURCE_WIDTH * (ACTUAL_MOBILE ? 1.10 : STORE_OWNED_RENDER_SCALE))
@@ -1047,6 +1049,7 @@ function DetailPanel({ weapon, embedded = false }: { weapon: LoadoutWeaponDefini
           >
             {!owned && (
               <UiEntity
+                key={`price-inner-${weapon.id}`}
                 uiTransform={{
                   flexDirection: 'row',
                   width: '100%',
@@ -1060,6 +1063,7 @@ function DetailPanel({ weapon, embedded = false }: { weapon: LoadoutWeaponDefini
                   uiTransform={{
                     width: scaleStoreImage(24),
                     height: scaleStoreImage(24),
+                    flexShrink: 0,
                     margin: { right: scaleStoreSpacing(6) }
                   }}
                   uiBackground={{
@@ -1073,6 +1077,7 @@ function DetailPanel({ weapon, embedded = false }: { weapon: LoadoutWeaponDefini
                   fontSize={scaleStoreFont(MOBILE ? 18 : 19)}
                   color={canAfford ? C.textGold : C.textBurgundy}
                   textAlign="middle-center"
+                  uiTransform={{ flex: 1, height: '100%', minWidth: 0 }}
                 />
               </UiEntity>
             )}
@@ -1102,7 +1107,8 @@ function DetailPanel({ weapon, embedded = false }: { weapon: LoadoutWeaponDefini
             borderRadius: 10,
             alignItems: 'center',
             justifyContent: 'center',
-            margin: { top: (showBuyButtonSprite || showUnlockPreviousButtonSprite || showDisabledBuyButtonSprite) ? scaleStoreSpacing(ACTUAL_MOBILE ? 8 : 8) : 0 }
+            margin: { top: (showBuyButtonSprite || showUnlockPreviousButtonSprite || showDisabledBuyButtonSprite) ? scaleStoreSpacing(ACTUAL_MOBILE ? 8 : 8) : 0 },
+            pointerFilter: 'block',
           }}
           uiBackground={actionBackground}
           onMouseDown={actionHandler}
@@ -1232,7 +1238,8 @@ export function LobbyStoreUi() {
           <UiEntity
             uiTransform={{
               width: ACTUAL_MOBILE ? Math.round(STORE_CLOSE_RENDER_WIDTH * 1.08) : STORE_CLOSE_RENDER_WIDTH,
-              height: ACTUAL_MOBILE ? Math.round(STORE_CLOSE_RENDER_HEIGHT * 1.08) : STORE_CLOSE_RENDER_HEIGHT
+              height: ACTUAL_MOBILE ? Math.round(STORE_CLOSE_RENDER_HEIGHT * 1.08) : STORE_CLOSE_RENDER_HEIGHT,
+              pointerFilter: 'block',
             }}
             uiBackground={{
               textureMode: 'stretch',

--- a/src/lobbyStoreUi.tsx
+++ b/src/lobbyStoreUi.tsx
@@ -631,7 +631,6 @@ function UpgradeCard({ weapon, isLast }: { weapon: LoadoutWeaponDefinition; isLa
         justifyContent: 'center',
         padding: { left: scaleStoreSpacing(6), right: scaleStoreSpacing(6) },
         flexShrink: 0,
-        pointerFilter: 'block',
       }}
       onMouseDown={() => { selectedWeaponId = weapon.id }}
     >
@@ -1107,8 +1106,7 @@ function DetailPanel({ weapon, embedded = false }: { weapon: LoadoutWeaponDefini
             borderRadius: 10,
             alignItems: 'center',
             justifyContent: 'center',
-            margin: { top: (showBuyButtonSprite || showUnlockPreviousButtonSprite || showDisabledBuyButtonSprite) ? scaleStoreSpacing(ACTUAL_MOBILE ? 8 : 8) : 0 },
-            pointerFilter: 'block',
+            margin: { top: (showBuyButtonSprite || showUnlockPreviousButtonSprite || showDisabledBuyButtonSprite) ? scaleStoreSpacing(ACTUAL_MOBILE ? 8 : 8) : 0 }
           }}
           uiBackground={actionBackground}
           onMouseDown={actionHandler}
@@ -1238,8 +1236,7 @@ export function LobbyStoreUi() {
           <UiEntity
             uiTransform={{
               width: ACTUAL_MOBILE ? Math.round(STORE_CLOSE_RENDER_WIDTH * 1.08) : STORE_CLOSE_RENDER_WIDTH,
-              height: ACTUAL_MOBILE ? Math.round(STORE_CLOSE_RENDER_HEIGHT * 1.08) : STORE_CLOSE_RENDER_HEIGHT,
-              pointerFilter: 'block',
+              height: ACTUAL_MOBILE ? Math.round(STORE_CLOSE_RENDER_HEIGHT * 1.08) : STORE_CLOSE_RENDER_HEIGHT
             }}
             uiBackground={{
               textureMode: 'stretch',


### PR DESCRIPTION
**Price label overflow (BUY → BUY navigation)**
The price badge in the detail panel was leaking outside its container when
navigating between two purchasable weapons. Root cause: DCL React-ECS
reconciler reuses existing nodes when the component tree structure is
identical (BUY→BUY), preserving the cached layout size from the previous
weapon instead of recalculating it. Fixed by:
- Adding `key="price-badge-{weapon.id}"` and `key="price-inner-{weapon.id}"`
  to force DCL to destroy and recreate the nodes on every weapon change.
- Adding `flex: 1 / minWidth: 0` to the price Label so it always fits
  within remaining space regardless of text length.
- Adding `flexShrink: 0` to the gold icon so it never gets compressed.

**Pointer filter**
Added `pointerFilter: 'block'` to all interactive elements (grid cards,
BUY/EQUIP action button, close button) to prevent click/tap events from
passing through the shop UI to 3D entities on both mobile and desktop.