### PR TITLE
fix: teleport player to lobby immediately when game over recap appears

### DIFF
--- a/src/multiplayer/lobbyClient.ts
+++ b/src/multiplayer/lobbyClient.ts
@@ -5,7 +5,7 @@ import { LobbyPhase, LobbyPlayer, LobbyStateComponent, LobbyStateSnapshot } from
 import { MatchRuntimeSnapshot, MatchRuntimeStateComponent, WaveCyclePhase } from '../shared/matchRuntimeSchemas'
 import { movePlayerTo } from '~system/RestrictedActions'
 import { Vector3 } from '@dcl/sdk/math'
-import { applyAuthoritativeHealthState, resetPlayerHealthAndLives } from '../playerHealth'
+import { applyAuthoritativeHealthState, resetPlayerHealthAndLives, setDeathMovementLockPosition } from '../playerHealth'
 import { resetDeathAnimationState, setLocalAvatarHidden } from '../deathAnimation'
 import { applyPlayerLoadoutSnapshot, getPlayerGold } from '../loadoutState'
 import { enableArenaWeapon, resetArenaWeaponProgress } from '../weaponManager'
@@ -13,7 +13,7 @@ import { resetToIdle } from '../waveManager'
 import { ArenaWeaponType } from '../shared/loadoutCatalog'
 import { START_GAME_COUNTDOWN_SECONDS, WAVE_ACTIVE_SECONDS, WAVE_REST_SECONDS } from '../shared/matchConfig'
 import { getCurrentRoomId as getRuntimeRoomId, setCurrentRoomId } from '../roomRuntime'
-import { DEFAULT_ROOM_ID, RoomId, getArenaRoomConfig, isRoomId } from '../shared/roomConfig'
+import { DEFAULT_ROOM_ID, LOBBY_RETURN_POSITION, RoomId, getArenaRoomConfig, isRoomId } from '../shared/roomConfig'
 import { getServerTime } from '../shared/timeSync'
 import { setIsoViewEnabled, setTopViewEnabled, setAutoFireEnabled, setCameraModeToggleEnabled } from '../gameplayInput'
 
@@ -187,6 +187,10 @@ export function setupLobbyClient(): void {
     latestLobbyEventAtMs = Date.now()
     if (data.type === 'team_wipe') {
       lastTeamWipeAffectedLocalPlayer = localReadyForMatch || localIsInArena
+      if (lastTeamWipeAffectedLocalPlayer) {
+        setDeathMovementLockPosition(LOBBY_RETURN_POSITION)
+        movePlayerTo({ newRelativePosition: LOBBY_RETURN_POSITION })
+      }
     } else {
       lastTeamWipeAffectedLocalPlayer = false
     }
@@ -240,6 +244,8 @@ export function setupLobbyClient(): void {
     if (data.isDead && data.lives <= 0) {
       captureLatestGameOverStatsSnapshot(localAddress)
       localGameOverActive = true
+      setDeathMovementLockPosition(LOBBY_RETURN_POSITION)
+      movePlayerTo({ newRelativePosition: LOBBY_RETURN_POSITION })
     }
   })
   room.onMessage('playerLoadoutState', (data) => {

--- a/src/playerHealth.ts
+++ b/src/playerHealth.ts
@@ -136,6 +136,10 @@ function captureDeathMovementLockPosition(): void {
   deathMovementLockPosition = Vector3.create(position.x, position.y, position.z)
 }
 
+export function setDeathMovementLockPosition(pos: Vector3): void {
+  deathMovementLockPosition = Vector3.create(pos.x, pos.y, pos.z)
+}
+
 function deadMovementLockSystem(): void {
   if (!isDead || !deathMovementLockPosition || !Transform.has(engine.PlayerEntity)) return
 


### PR DESCRIPTION
## Summary
- When a player is eliminated (0 lives left) or a team wipe event is received, the player is now teleported to the lobby immediately as the recap UI appears, instead of waiting for them to press the "Back to Lobby" button.
- Fixed the root cause: `deadMovementLockSystem` was overriding the teleport every frame by snapping the dead player back to their death position in the arena. By calling `setDeathMovementLockPosition(LOBBY_RETURN_POSITION)` before the teleport, the lock anchor is moved to the lobby so the system keeps the player there instead of fighting back.

## Changes
- `src/playerHealth.ts` — exported `setDeathMovementLockPosition` to allow external callers to relocate the movement lock anchor
- `src/multiplayer/lobbyClient.ts` — on `playerHealthState` (lives ≤ 0) and on `team_wipe` event (local player affected), call `setDeathMovementLockPosition` + `movePlayerTo` with `LOBBY_RETURN_POSITION`

## Test plan
- [ ] Die twice in a match — recap UI should appear while already standing in the lobby
- [ ] Have the full team wiped — all players should be teleported to the lobby when the recap triggers
- [ ] Confirm recap UI still displays correctly and "Back to Lobby" button closes it normally
- [ ] Confirm normal mid-match death (with lives remaining) still works — player should respawn in arena as usual


Closes #306 