### PR TITLE
Fix: Leaderboards-writting-on-end-game

### DIFF
--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -827,6 +827,14 @@ function eliminatePlayerFromMatch(address: string, roomId: RoomId): void {
 
   logLobbyServerEvent(roomId, `PlayerEliminated ${normalizedAddress}`)
 
+  // Persist the eliminated player's match stats before the match-end chain wipes the stat maps
+  // (resetArenaToLobby → resetMatchLeaderboardStats). Without this, the leaderboard never records
+  // players who die in-arena — only those who disconnect mid-match (handled by removePlayerFromLobby).
+  if (commitPlayerMatchStatsToLeaderboard(roomId, player)) {
+    syncLeaderboardToComponent()
+    void leaderboardStore.persist()
+  }
+
   const nextArenaPlayers = lobbyState.arenaPlayers.filter((p) => p.address !== normalizedAddress)
   setArenaPlayers(roomId, nextArenaPlayers)
 


### PR DESCRIPTION
In this PR:
Only one change, in [lobbyServer.ts](vscode-webview://1be97fqup6lc15r4dm0df4ikbnojsr0aeo52734m3nk8174qo0pk/src/server/lobbyServer.ts) inside eliminatePlayerFromMatch:

Before removing the eliminated player from arenaPlayers, call commitPlayerMatchStatsToLeaderboard(roomId, player) followed by syncLeaderboardToComponent() and leaderboardStore.persist() if anything changed.

Closes #307 