### PR TITLE
ft: format leaderboard names

### DIFF
--- a/src/LeaderboardWorldPanel.ts
+++ b/src/LeaderboardWorldPanel.ts
@@ -11,10 +11,13 @@ function formatLeaderboardName(displayName: string, address: string, maxLen: num
   const baseName = displayName && displayName.length > 0 ? displayName : fallbackName
   const suffix = `#${address.slice(-4)}`
   const fullName = `${baseName}${suffix}`
+  const safeMaxLen = Math.max(1, maxLen)
 
-  if (fullName.length <= maxLen) return fullName
+  if (fullName.length <= safeMaxLen) return fullName
+  if (safeMaxLen <= suffix.length) return suffix.slice(0, safeMaxLen)
+  if (safeMaxLen === suffix.length + 1) return `…${suffix}`
 
-  const maxBaseLength = Math.max(1, maxLen - suffix.length)
+  const maxBaseLength = safeMaxLen - suffix.length
   return `${baseName.slice(0, Math.max(1, maxBaseLength - 1))}…${suffix}`
 }
 

--- a/src/LeaderboardWorldPanel.ts
+++ b/src/LeaderboardWorldPanel.ts
@@ -6,9 +6,16 @@ import { getLeaderboardKills, getLeaderboardWaves } from './multiplayer/lobbyCli
 
 const PANEL_UPDATE_INTERVAL = 0.5
 
-function truncateName(displayName: string, address: string, maxLen: number = 14): string {
-  const name = displayName && displayName.length > 0 ? displayName : address.slice(0, 8)
-  return name.length > maxLen ? name.slice(0, maxLen - 1) + '…' : name
+function formatLeaderboardName(displayName: string, address: string, maxLen: number = 14): string {
+  const fallbackName = address.slice(0, 6)
+  const baseName = displayName && displayName.length > 0 ? displayName : fallbackName
+  const suffix = `#${address.slice(-4)}`
+  const fullName = `${baseName}${suffix}`
+
+  if (fullName.length <= maxLen) return fullName
+
+  const maxBaseLength = Math.max(1, maxLen - suffix.length)
+  return `${baseName.slice(0, Math.max(1, maxBaseLength - 1))}…${suffix}`
 }
 
 export function initLeaderboardWorldPanel(): void {
@@ -58,7 +65,7 @@ export function initLeaderboardWorldPanel(): void {
 
     const killsEntries = getLeaderboardKills()
     const killsData: LeaderboardPanelEntry[] = killsEntries.map((e) => ({
-      name: truncateName(e.displayName, e.address),
+      name: formatLeaderboardName(e.displayName, e.address),
       value: String(e.value)
     }))
     const killsKey = killsData.map((e) => `${e.name}:${e.value}`).join('|')
@@ -69,7 +76,7 @@ export function initLeaderboardWorldPanel(): void {
 
     const wavesEntries = getLeaderboardWaves()
     const wavesData: LeaderboardPanelEntry[] = wavesEntries.map((e) => ({
-      name: truncateName(e.displayName, e.address),
+      name: formatLeaderboardName(e.displayName, e.address),
       value: String(e.value)
     }))
     const wavesKey = wavesData.map((e) => `${e.name}:${e.value}`).join('|')

--- a/src/server/lobbyServer.ts
+++ b/src/server/lobbyServer.ts
@@ -494,6 +494,45 @@ function getPlayerDisplayName(address: string): string {
   return normalizedAddress.slice(0, 8)
 }
 
+function isAddressDerivedDisplayName(displayName: string, address: string): boolean {
+  const normalizedAddress = address.toLowerCase()
+  const normalizedDisplayName = displayName.trim().toLowerCase()
+
+  if (!normalizedDisplayName) return true
+
+  return (
+    normalizedDisplayName === normalizedAddress ||
+    normalizedDisplayName === normalizedAddress.slice(0, 8) ||
+    normalizedDisplayName === normalizedAddress.slice(0, 6) ||
+    normalizedDisplayName === `${normalizedAddress.slice(0, 6)}...${normalizedAddress.slice(-4)}` ||
+    normalizedDisplayName === `${normalizedAddress.slice(0, 6)}#${normalizedAddress.slice(-4)}`
+  )
+}
+
+function pickPreferredDisplayName(address: string, ...candidates: Array<string | null | undefined>): string {
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const trimmedCandidate = candidate.trim()
+    if (!trimmedCandidate) continue
+    if (!isAddressDerivedDisplayName(trimmedCandidate, address)) return trimmedCandidate
+  }
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const trimmedCandidate = candidate.trim()
+    if (trimmedCandidate) return trimmedCandidate
+  }
+
+  return address.toLowerCase().slice(0, 8)
+}
+
+function getResolvedPlayerDisplayName(address: string): string {
+  const normalizedAddress = address.toLowerCase()
+  const liveDisplayName = getPlayerDisplayName(normalizedAddress)
+  const cachedDisplayName = playerProgressStore.get(normalizedAddress)?.profile.lastKnownName
+  return pickPreferredDisplayName(normalizedAddress, liveDisplayName, cachedDisplayName)
+}
+
 function getLobbyStateMutable(roomId: RoomId) {
   const roomState = getRoomServerState(roomId)
   if (roomState.lobbyEntity === null) {
@@ -1231,18 +1270,37 @@ async function ensurePlayerLoadedAndInLobby(roomId: RoomId, address: string): Pr
 
 async function ensurePlayerProfileLoaded(address: string): Promise<void> {
   const normalizedAddress = address.toLowerCase()
+  const displayName = getResolvedPlayerDisplayName(normalizedAddress)
+
   if (loadedProfileAddresses.has(normalizedAddress)) {
+    const cached = playerProgressStore.get(normalizedAddress)
+    if (cached && cached.profile.lastKnownName !== displayName) {
+      playerProgressStore.mutate(normalizedAddress, (progress) => {
+        progress.profile.lastKnownName = displayName
+      })
+    }
     sendPlayerLoadoutState(normalizedAddress)
     return
   }
-  const displayName = getPlayerDisplayName(normalizedAddress)
+
   const progress = await playerProgressStore.load(normalizedAddress, displayName)
+  const resolvedDisplayName = pickPreferredDisplayName(
+    normalizedAddress,
+    getPlayerDisplayName(normalizedAddress),
+    progress.profile.lastKnownName,
+    displayName
+  )
+  if (progress.profile.lastKnownName !== resolvedDisplayName) {
+    playerProgressStore.mutate(normalizedAddress, (state) => {
+      state.profile.lastKnownName = resolvedDisplayName
+    })
+  }
   loadedProfileAddresses.add(normalizedAddress)
   sendPlayerLoadoutState(normalizedAddress)
-  console.log(`[Server][Lobby] ProfileLoaded ${displayName} (${normalizedAddress})`)
+  console.log(`[Server][Lobby] ProfileLoaded ${resolvedDisplayName} (${normalizedAddress})`)
   sendMessage('lobbyEvent', {
     type: 'profile_loaded',
-    message: `${displayName} profile loaded (GOLD ${progress.profile.gold})`
+    message: `${resolvedDisplayName} profile loaded (GOLD ${progress.profile.gold})`
   }, [normalizedAddress])
 }
 
@@ -1293,7 +1351,8 @@ function addPlayerToLobby(roomId: RoomId, address: string): void {
   if (state.players.some((p) => p.address === normalizedAddress)) return
   if (state.players.length >= MATCH_MAX_PLAYERS) return
 
-  const nextPlayers = [...state.players, { address: normalizedAddress, displayName: getPlayerDisplayName(normalizedAddress) }]
+  const displayName = getResolvedPlayerDisplayName(normalizedAddress)
+  const nextPlayers = [...state.players, { address: normalizedAddress, displayName }]
   playerRoomByAddress.set(normalizedAddress, roomId)
   setPlayers(roomId, nextPlayers)
 
@@ -1310,12 +1369,12 @@ function addPlayerToLobby(roomId: RoomId, address: string): void {
 
   logLobbyServerEvent(
     roomId,
-    `PlayerJoined ${getPlayerDisplayName(normalizedAddress)} ${nextPlayers.length}/${MATCH_MAX_PLAYERS}`
+    `PlayerJoined ${displayName} ${nextPlayers.length}/${MATCH_MAX_PLAYERS}`
   )
 
   sendToLobby(roomId, 'lobbyEvent', {
     type: 'join',
-    message: `${getPlayerDisplayName(normalizedAddress)} joined lobby`
+    message: `${displayName} joined lobby`
   })
 }
 
@@ -1823,18 +1882,30 @@ function syncLeaderboardToComponent(): void {
 function commitPlayerMatchStatsToLeaderboard(roomId: RoomId, player: LobbyPlayer): boolean {
   const progress = playerProgressStore.get(player.address)
   if (!progress) return false
+  const displayName = pickPreferredDisplayName(
+    player.address,
+    getPlayerDisplayName(player.address),
+    progress.profile.lastKnownName,
+    player.displayName
+  )
+
+  if (progress.profile.lastKnownName !== displayName) {
+    playerProgressStore.mutate(player.address, (state) => {
+      state.profile.lastKnownName = displayName
+    })
+  }
 
   const roomState = getRoomServerState(roomId)
   const killsChanged = leaderboardStore.update(
     'kills',
     player.address,
-    progress.profile.lastKnownName,
+    displayName,
     roomState.playerMatchKillsByAddress.get(player.address) ?? 0
   )
   const wavesChanged = leaderboardStore.update(
     'waves',
     player.address,
-    progress.profile.lastKnownName,
+    displayName,
     roomState.playerMatchWavesSurvivedByAddress.get(player.address) ?? 0
   )
 


### PR DESCRIPTION
Updated leaderboard name handling to consistently prefer real player names over wallet-derived fallbacks, and changed the world leaderboard display format to name#last4 while preserving the wallet suffix when truncation is needed.

Closes #310 