### PR TITLE
ft: random respawn

### DIFF
--- a/src/playerHealth.ts
+++ b/src/playerHealth.ts
@@ -140,6 +140,31 @@ export function setDeathMovementLockPosition(pos: Vector3): void {
   deathMovementLockPosition = Vector3.create(pos.x, pos.y, pos.z)
 }
 
+function chooseRespawnPosition(): { x: number; y: number; z: number } {
+  const roomConfig = getCurrentRoomConfig()
+  const respawnPoints = roomConfig.respawnPoints
+
+  if (respawnPoints.length === 0) return roomConfig.respawnPosition
+  if (respawnPoints.length === 1 || !deathMovementLockPosition) {
+    return respawnPoints[Math.floor(Math.random() * respawnPoints.length)]
+  }
+  const deathPosition = deathMovementLockPosition
+
+  const rankedPoints = [...respawnPoints]
+    .map((point) => {
+      const dx = point.x - deathPosition.x
+      const dz = point.z - deathPosition.z
+      return {
+        point,
+        distanceSq: dx * dx + dz * dz
+      }
+    })
+    .sort((left, right) => right.distanceSq - left.distanceSq)
+
+  const candidateCount = Math.min(2, rankedPoints.length)
+  return rankedPoints[Math.floor(Math.random() * candidateCount)].point
+}
+
 function deadMovementLockSystem(): void {
   if (!isDead || !deathMovementLockPosition || !Transform.has(engine.PlayerEntity)) return
 
@@ -168,7 +193,7 @@ export function initPlayerDeathMovementLockSystem(): void {
 /** Respawn player: move to spawn, restore HP, clear death state. */
 export function respawnPlayer(): void {
   const roomConfig = getCurrentRoomConfig()
-  const respawnPosition = roomConfig.respawnPosition
+  const respawnPosition = chooseRespawnPosition()
   const respawnLookAt = roomConfig.respawnLookAt
   movePlayerTo({
     newRelativePosition: { x: respawnPosition.x, y: respawnPosition.y, z: respawnPosition.z },

--- a/src/shared/roomConfig.ts
+++ b/src/shared/roomConfig.ts
@@ -81,6 +81,7 @@ export type ArenaRoomConfig = {
   arenaCenter: Vector3
   arenaTeleportPosition: { x: number; y: number; z: number }
   arenaTeleportLookAt: { x: number; y: number; z: number }
+  respawnPoints: Array<{ x: number; y: number; z: number }>
   respawnPosition: { x: number; y: number; z: number }
   respawnLookAt: { x: number; y: number; z: number }
   spawnMinX: number
@@ -96,6 +97,14 @@ export type ArenaRoomConfig = {
   floorSizeX: number
   floorSizeZ: number
 }
+
+const RESPAWN_POINT_OFFSET = 15
+const RESPAWN_POINT_LAYOUT = [
+  { x: -RESPAWN_POINT_OFFSET, z: -RESPAWN_POINT_OFFSET },
+  { x: RESPAWN_POINT_OFFSET, z: -RESPAWN_POINT_OFFSET },
+  { x: -RESPAWN_POINT_OFFSET, z: RESPAWN_POINT_OFFSET },
+  { x: RESPAWN_POINT_OFFSET, z: RESPAWN_POINT_OFFSET }
+] as const
 
 function createArenaRoomConfig(roomId: RoomId, sceneLayout?: SceneArenaLayout): ArenaRoomConfig {
   const offset = ROOM_WORLD_OFFSET_BY_ID[roomId]
@@ -121,6 +130,11 @@ function createArenaRoomConfig(roomId: RoomId, sceneLayout?: SceneArenaLayout): 
   const brickMaxX = sceneLayout ? centerX + (ARENA_BRICK_MAX_X - ARENA_CENTER_X) : ARENA_BRICK_MAX_X + offset.x
   const brickMinZ = sceneLayout ? centerZ + (ARENA_BRICK_MIN_Z - ARENA_CENTER_Z) : ARENA_BRICK_MIN_Z + offset.z
   const brickMaxZ = sceneLayout ? centerZ + (ARENA_BRICK_MAX_Z - ARENA_CENTER_Z) : ARENA_BRICK_MAX_Z + offset.z
+  const respawnPoints = RESPAWN_POINT_LAYOUT.map((point) => ({
+    x: centerX + point.x,
+    y: centerY,
+    z: centerZ + point.z
+  }))
 
   return {
     roomId,
@@ -131,7 +145,8 @@ function createArenaRoomConfig(roomId: RoomId, sceneLayout?: SceneArenaLayout): 
     arenaCenter: Vector3.create(centerX, centerY, centerZ),
     arenaTeleportPosition: { x: centerX, y: centerY, z: centerZ },
     arenaTeleportLookAt: { x: lookAtX, y: lookAtY, z: lookAtZ },
-    respawnPosition: { x: centerX, y: centerY, z: centerZ },
+    respawnPoints,
+    respawnPosition: respawnPoints[0],
     respawnLookAt: { x: lookAtX, y: lookAtY, z: lookAtZ },
     spawnMinX,
     spawnMaxX,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -20,7 +20,13 @@ import { getGameTime } from './zombie'
 import { isSpeedActive, getSpeedTimeLeft, SPEED_DURATION_SEC } from './speedEffect'
 import { isRaging, getRageTimeLeft, RAGE_DURATION_SEC } from './rageEffect'
 import { getHealthPickupFeedback } from './potions'
-import { beginUiPointerCapture, endUiPointerCapture, isAutoFireEnabled, isTopViewEnabled, isIsoViewEnabled } from './gameplayInput'
+import {
+  beginUiPointerCapture,
+  endUiPointerCapture,
+  isAutoFireEnabled,
+  isTopViewEnabled,
+  isIsoViewEnabled
+} from './gameplayInput'
 import {
   getCurrentWeapon,
   getWeaponUnlockCost,


### PR DESCRIPTION
Added multi-point respawn support for all four arenas and changed respawn selection to choose randomly among the farthest available safe points from the player’s death location.

This keeps respawns away from the exact death area, preserves arena-relative positioning across every room, and removes the temporary debug teleport UI used to validate the spawn points locally.

Closes #305 