### PR TITLE
fix: Add-new-world

### DIFF
--- a/scene.json
+++ b/scene.json
@@ -134,7 +134,7 @@
     "projectId": "ee11107b-db00-456a-b31d-76845766f2fb"
   },
   "worldConfiguration": {
-    "name": "toastedllama.dcl.eth"
+    "name": "deadsurge.dcl.eth"
   },
   "authoritativeMultiplayer": true,
   "multiplayerId": "survivalgame",

--- a/storage-export.json
+++ b/storage-export.json
@@ -1,0 +1,27195 @@
+{
+  "exportedAt": "2026-06-15T15:10:04.364Z",
+  "sourceWorld": "toastedllama.dcl.eth",
+  "sceneData": {
+    "leaderboard_kills_v2": "[{\"address\":\"0x3f6b1d01b6823ab235fc343069b62b6472774cd1\",\"displayName\":\"MetaRyuk\",\"value\":1141},{\"address\":\"0x797520f471de8ec7b1e771e014149c4fd408367c\",\"displayName\":\"FredElf\",\"value\":471},{\"address\":\"0x8218a2445679e38f358e42f88fe2125c98440d59\",\"displayName\":\"Noob\",\"value\":411},{\"address\":\"0x3aee16d4613468d5a9926e1a982f168e5370a469\",\"displayName\":\"Ponter\",\"value\":381},{\"address\":\"0x6788772313bac0a4d7c4405cdaafc953c317a8c2\",\"displayName\":\"Ember\",\"value\":295},{\"address\":\"0xd2b1116d2eac248b267bb51cc96c1b035d73d9e7\",\"displayName\":\"RimuruT\",\"value\":273},{\"address\":\"0xebca4b89f56810462f41ca4e2e1985dcdf42f729\",\"displayName\":\"RandomGuy\",\"value\":271},{\"address\":\"0xeb0c682e1ca11e62eabe436ea36459d57616e5f1\",\"displayName\":\"OtoLam\",\"value\":257},{\"address\":\"0x910b8d15790aeb437bad544c49628e013b7c3140\",\"displayName\":\"Losss\",\"value\":247},{\"address\":\"0xe40afb3a5eb1cfde05cbc01deafa45a56a4e7cb3\",\"displayName\":\"CavinM\",\"value\":242}]",
+    "leaderboard_waves_v2": "[{\"address\":\"0x3f6b1d01b6823ab235fc343069b62b6472774cd1\",\"displayName\":\"MetaRyuk\",\"value\":45},{\"address\":\"0x4cf48444704d1a6f1797c718ea5c40a53dbecc5b\",\"displayName\":\"RAINBOWDASH1423\",\"value\":27},{\"address\":\"0x8218a2445679e38f358e42f88fe2125c98440d59\",\"displayName\":\"Noob\",\"value\":17},{\"address\":\"0x797520f471de8ec7b1e771e014149c4fd408367c\",\"displayName\":\"FredElf\",\"value\":17},{\"address\":\"0xd2b1116d2eac248b267bb51cc96c1b035d73d9e7\",\"displayName\":\"RimuruT\",\"value\":16},{\"address\":\"0xebca4b89f56810462f41ca4e2e1985dcdf42f729\",\"displayName\":\"RandomGuy\",\"value\":15},{\"address\":\"0xeb0c682e1ca11e62eabe436ea36459d57616e5f1\",\"displayName\":\"OtoLam\",\"value\":15},{\"address\":\"0xcc2621f8a1974d50631c85922f2b921867a397e1\",\"displayName\":\"JimSedric\",\"value\":14},{\"address\":\"0xddf0e06b3b52eb6d081c5e76be6d9879fe8d6a1b\",\"displayName\":\"Stephy\",\"value\":14},{\"address\":\"0x3aee16d4613468d5a9926e1a982f168e5370a469\",\"displayName\":\"Ponter\",\"value\":14}]"
+  },
+  "playerData": {
+    "0x009084a7a7df2ac6be8fe5fd6b0bd40c481244eb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780596853843,
+        "lastKnownName": "mohammad ali",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780596853844,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780596853844,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x017af83aca662d76ea196831b0069880861c5f09": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778507591583,
+        "lastKnownName": "Roman",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778507591583,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778507591583,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x01a6c9f58e3ddd060a9e0256999bcce5f3dcaaa7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781448727520,
+        "lastKnownName": "Nova Nightwing",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781448727520,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781448727520,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x010aefb48921f7473033828ab181a09f935b343d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779830406273,
+        "lastKnownName": "0x010aef",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 51
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779830406273,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779830406273,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x017ca6eda03270a4b49619a831ae81afa1d04b8e": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780178577553,
+        "lastKnownName": "looneyz",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 1,
+          "zombiesKilled": 100
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780178577553,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780178577553,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x025d9a4f8a0b8ec4815f214f6393af5b2d273d30": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781190837124,
+        "lastKnownName": "Chule",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781190837125,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781190837125,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x030e4e943284e939e3ae863c9d79707cfdfb9b41": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780353464442,
+        "lastKnownName": "Niro",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780353464442,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780353464442,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0275260aab6b5b1b9de1d648cbe2d6c32bf67cb8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779466499664,
+        "lastKnownName": "pierrot",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 20
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779466499664,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779466499664,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x04f66fd72a92ef7d8cb597c45d9931a2900ea3fd": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780060450963,
+        "lastKnownName": "jazz",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 44
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780060450963,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780060450963,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x03446eb67b731c4581f365143e553e89c341e781": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780169635830,
+        "lastKnownName": "Sony",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 3,
+          "zombiesKilled": 85
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780169635830,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780169635830,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x049caba207a3cf9aba591a6ab21d7a1805921e2e": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780665705455,
+        "lastKnownName": "AlmostLean",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780665705455,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780665705455,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x04120ded3ec756d0ccb573513ddfc53d6afa88c9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779635580002,
+        "lastKnownName": "Zara Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 43
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779635580002,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779635580002,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x06bd54affb47345126c36579d51e8cb11a33e598": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780239147319,
+        "lastKnownName": "Escaflon",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780239147319,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780239147319,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x070f99855d4a4544340ab461eae53922aec14a5d": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779726137650,
+        "lastKnownName": "carrito",
+        "lifetimeStats": {
+          "wavesCleared": 20,
+          "matchesPlayed": 4,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779726137650,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779726137650,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x07752012ea7475da9efd46371dbc2220b9f13b54": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1774618201886,
+        "lastKnownName": "SebaDL",
+        "lifetimeStats": {
+          "wavesCleared": 12,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1774618201886,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1774618201886,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x07ec065c01643fffb176cb12cefed77dcec59b7b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779799548624,
+        "lastKnownName": "yuta",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779799548624,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779799548624,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x08759aa5eb7d86349381c4b2ea964724e75af923": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780076426751,
+        "lastKnownName": "exe3034",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 12
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780076426751,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780076426751,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x087b684ef37a870e4cf0dc9a0dab2210457b01b6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780449489737,
+        "lastKnownName": "bakugo",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780449489737,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780449489737,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0895c8f10767f73bca48d5a9ccf1210b92c94ada": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780951714291,
+        "lastKnownName": "M",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780951714291,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780951714291,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x087eabd368286c23f4fa5248d5cb9a937315bac0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780006094213,
+        "lastKnownName": "murilo",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780006094213,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780006094213,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x08ae9a99f41709a40db34db3668b549d961db817": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780048822294,
+        "lastKnownName": "nininho",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780048822294,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780048822294,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0907aced1a7f0388646d1b5a40b8fc2a66f1ff33": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781119274831,
+        "lastKnownName": "shahin",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781119274831,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781119274831,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x090b68b6d07de7fd01aba44bcc7efff9e31de865": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780608271445,
+        "lastKnownName": "Neymar Jr",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780608271445,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780608271445,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0b6509f4ef3a62068caff935d77f5a955bd1e631": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780507008095,
+        "lastKnownName": "Fkliveone",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 2,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780507008095,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780507008095,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0b39d60d6bf7af7bbff529621b7b68e0781052f3": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781394009928,
+        "lastKnownName": "Matin4133",
+        "lifetimeStats": {
+          "wavesCleared": 9,
+          "matchesPlayed": 1,
+          "zombiesKilled": 148
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781394009928,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781394009928,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x09e164986ac5d1dc2698cea18cf22537a045fa4d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781279265053,
+        "lastKnownName": "Orion Voidseeker",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781279265053,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781279265053,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0bb6cf23bd5211adde4e647055c1ce22b2937fb0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779879901478,
+        "lastKnownName": "0x0bb6cf",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779879901478,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779879901478,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0e49d09030a1f455bfa6441430521693ec211aa0": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779666925405,
+        "lastKnownName": "Rickyyy",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 28
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779666925405,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779666925405,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0c233ed02cbb3d7b4cbb0cbd1f3914ef7e76e6c8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779688558686,
+        "lastKnownName": "Lukauz",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 2,
+          "zombiesKilled": 61
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779688558686,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779688558686,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0e98bb3897121a60491c1be107a72654c8e66f48": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779890418230,
+        "lastKnownName": "0x0e98bb",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779890418230,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779890418230,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0e5cf382d9ced734f78977e178b17502d3b8fae1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778618762640,
+        "lastKnownName": "PRimeModone",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 48
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778618762640,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778618762640,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0ed87d48a17a7e8f029a0e0ddbdba99a94b1d343": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780528981871,
+        "lastKnownName": "barbas",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 2,
+          "zombiesKilled": 7
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780528981871,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780528981871,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0ef39d45b11b9272ab19baf167cdc67f9a6ab342": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779803634774,
+        "lastKnownName": "VALENTIN",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779803634774,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779803634774,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x0f9db39fd4b9432c0d3a7ed16baa37f404e1a71a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780100166081,
+        "lastKnownName": "Liebe",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780100166081,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780100166081,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x113f83bf68f04ded65f6cf6e63bfb126f297241f": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780742098400,
+        "lastKnownName": "Cyrus Lotus",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 2,
+          "zombiesKilled": 118
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780742098400,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780742098400,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x11893583cb8b54decac8bb2c53085e8b3ef37658": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780234434899,
+        "lastKnownName": "CryptoPanda",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 63
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780234434899,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780234434899,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1257ee9d2d372b3781230cfffe0a9d2e75ad41ff": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779725103073,
+        "lastKnownName": "gabyelf",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779725103073,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779725103073,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x11908c519ce13a876ca60a771fce7afa136cf9a1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779553655166,
+        "lastKnownName": "Neo Stargazer",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779553655166,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779553655166,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x12824f8dff4714059517ced1226f6c7ee06d97cc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779719280818,
+        "lastKnownName": "Iris Raveneye",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 4
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779719280818,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779719280818,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x12bb4a70289a06dbe1b68b31d6e2f2b1981473cd": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780055123954,
+        "lastKnownName": "Charmnoru",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780055123955,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780055123955,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x144b009c8cdc7649c93f1a9e3de87a232a788ba8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780446668448,
+        "lastKnownName": "BigJ",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 2,
+          "zombiesKilled": 31
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780446668448,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780446668448,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1303112f4049a93cc686f31a7b2bdfb03127b9b0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779604603231,
+        "lastKnownName": "0x130311",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779604603231,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779604603231,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x13269cd472fc06e0abbd1e4dd8679099d9428e8d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780484017183,
+        "lastKnownName": "Yvess Saint",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 34
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780484017183,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780484017183,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1399a5b9229e787d2e2657b717c8891cf72c460c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780271631019,
+        "lastKnownName": "machipibositoto",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 8
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780271631019,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780271631019,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x145c9de49b87d8be1fcf1d2040627526ec3832cb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779455163724,
+        "lastKnownName": "kangurin",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 14
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779455163724,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779455163724,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x141c9090a85540180598f69f198fd7957275b395": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779623123643,
+        "lastKnownName": "Beatriz123",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779623123643,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779623123643,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x15499b0ad989a9a839a4b37fb15c0ad0cfa2b602": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780244338046,
+        "lastKnownName": "Taufik",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 46
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780244338046,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780244338046,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x14a2d26b6077cf46b543321172cf4cfe4e6a76f5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780485339162,
+        "lastKnownName": "0x14a2d2",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780485339162,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780485339162,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1509b9c055a2c6e6d157ff2e2e9d638e75f449d6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780147453653,
+        "lastKnownName": "jandel",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780147453653,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780147453653,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x177170aa541a13e6709b98a073f3483c7dfd77b1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778367199395,
+        "lastKnownName": "PEDRO",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778367199395,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778367199395,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x16bc4dc8ac6ebd6a36fcb98c0cb92b65a9613cbf": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779628215864,
+        "lastKnownName": "r3uus43",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 3,
+          "zombiesKilled": 61
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779628215864,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779628215864,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x155de3f220a9e09c7749f4d357fa669a6e1a5d8f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780251410022,
+        "lastKnownName": "NecroticPenguin",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780251410022,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780251410022,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x18c28e1b5ab8bb2271a9ae77fed6f1228b429887": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780109887053,
+        "lastKnownName": "Tornado",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 19
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780109887053,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780109887053,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x192a58b4f34973f8bd33cbd2ad98ba046f20decc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780228470073,
+        "lastKnownName": "0x192a58",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780228470073,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780228470073,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1897dfbbcdda195c01afdef1f47bc7631fe25872": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779895147737,
+        "lastKnownName": "Gabrielg9",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779895147737,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779895147737,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x19b57a8c9c05884ad3b91d4cc2ca3b3727e169da": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1776736054117,
+        "lastKnownName": "Jjdyhdh",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 2,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1776736054117,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1776736054117,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1a024eabf0036412674df34b3f3a473d92933c0d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780547704208,
+        "lastKnownName": "Lucius2002",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 18
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780547704208,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780547704208,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x19d3305a361fb0cab564402ad3f199e301849b8e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780162867103,
+        "lastKnownName": "THJA",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 18
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780162867103,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780162867103,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1bc8bbc9c6c38ed64a1fd75b4d55b791fa545197": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778647258992,
+        "lastKnownName": "ErickM2290",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778647258992,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778647258992,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1a4642f238e492090d6a2120a4879d9969944059": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779996181550,
+        "lastKnownName": "Luna Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 1,
+          "zombiesKilled": 71
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779996181550,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779996181550,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1a40f2d795545a001c98dec5d411bd05bdbaf296": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1774618164623,
+        "lastKnownName": "Antonio",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1774618164623,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1774618164623,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1e105bb213754519903788022b962fe2b9c4b263": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778075037038,
+        "lastKnownName": "BayBackner",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778075037038,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778075037038,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1bdc83dee52dbc276a2b73400ddb4134e774f011": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779529202438,
+        "lastKnownName": "JohnDuperPlay",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779529202438,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779529202438,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1e8eb19ab7311427e06a2ad1695d6aa79690b746": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780160477491,
+        "lastKnownName": "Seren Raveneye",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780160477491,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780160477492,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1e9355decfb81f2fcad297bf66c4c36fd4166034": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780417973642,
+        "lastKnownName": "davinci",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780417973642,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780417973642,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1eae969d4dc90a39aa8fa4171dab2741997f7261": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780713983796,
+        "lastKnownName": "Diego",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780713983796,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780713983796,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1e9355bc0310054e48c06211ffd2af5f48031cee": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779418014008,
+        "lastKnownName": "e",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 70
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779418014008,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779418014008,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1ee6a6ff10fe09ba321428e3549396ade1b5c9c9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1774012357025,
+        "lastKnownName": "EibrieliOs",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1774012357025,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1774012357025,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2119f0a7acf5398c9a590d8e89bba7f3a1774291": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780624806214,
+        "lastKnownName": "Driady",
+        "lifetimeStats": {
+          "wavesCleared": 22,
+          "matchesPlayed": 4,
+          "zombiesKilled": 208
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780624806215,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780624806215,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x1ecbf5d5542d82a3939d4b47b22bcd3034c0645e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779610661868,
+        "lastKnownName": "Subaru",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779610661868,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779610661868,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x218638570812ed1b124e58bb174dcc0d278c1c44": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780163759476,
+        "lastKnownName": "pepejuan",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 2
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780163759476,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780163759476,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x21e1fecdb028418b82f4af4452b64fd4c3afce69": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779587072771,
+        "lastKnownName": "Breu",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779587072771,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779587072771,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x21637d43b0aab2f1161472e1ce6391fde57eae43": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779576094320,
+        "lastKnownName": "AbuHAzraelD47",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 40
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779576094320,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779576094320,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x22d31a1c2cabb6c98f7c60884bca389f3753d02a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780124613083,
+        "lastKnownName": "Random",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780124613083,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780124613083,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x22d64d03f3122e7a8e2148b76326a9d0997ebb08": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780047887545,
+        "lastKnownName": "Salim",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780047887545,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780047887545,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x22c9c6ae06b45999848e478b6d548c0c760513fc": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1781437758894,
+        "lastKnownName": "vk7",
+        "lifetimeStats": {
+          "wavesCleared": 18,
+          "matchesPlayed": 6,
+          "zombiesKilled": 172
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781437758894,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781437758894,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x23b2ccfeac8084d3469efb5fb1668942b131de9f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780695014552,
+        "lastKnownName": "Seren Skyforge",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 43
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780695014552,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780695014552,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x231f2c5a877e54048c76ae84d387c7e00bbec8c0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780096433624,
+        "lastKnownName": "reka",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780096433624,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780096433624,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x23b5a27959d0ee59f77007d810dba7b0497d5906": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780085607230,
+        "lastKnownName": "Nat",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780085607230,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780085607230,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x23b93f2bf093fb0ded357819dd2dbaecb499b3c8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779897538143,
+        "lastKnownName": "massleu",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779897538143,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779897538143,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x241548902556f1c6673cfdc4fbe86926e842ec0e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780830533509,
+        "lastKnownName": "Dasher",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780830533509,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780830533509,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x247e0896706bb09245549e476257a0a1129db418": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779606700645,
+        "lastKnownName": "DCLCars",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 17
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779606700645,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779606700645,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x26c6a5c896d1b98e216a76bb57ab4396b7a902ee": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779934685540,
+        "lastKnownName": "0x26c6a5",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779934685540,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779934685540,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2512e7f469a1d8e315d4a5014d87bcb21cbd653d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780288791938,
+        "lastKnownName": "Violet",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780288791938,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780288791938,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2688c194f3e9d340e664e23e8a1baaa7d11b5f76": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779554930315,
+        "lastKnownName": "MrMayz",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 138
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779554930315,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779554930315,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x273a2c612c2b2ef8d8c1bbe28bfc6b696343d2ec": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780619424159,
+        "lastKnownName": "DrawOrigami",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780619424159,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780619424159,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x27583c85c7ac5d9128628ab072aa614c9b73cd4b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780068096636,
+        "lastKnownName": "Arthur",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 11
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780068096636,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780068096636,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x27dced90d9dc7f1f9d4a50456023dfb64687cbb6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780529421255,
+        "lastKnownName": "javadirani",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780529421255,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780529421255,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2a1ebad35dff8a80f62afadd62701756721735d5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780166867010,
+        "lastKnownName": "Thane Stargazer",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780166867010,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780166867010,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x28d663387cea9a5552b36da6fdf60fdc7b3149c9": {
+      "profile_v1": {
+        "gold": 7,
+        "updatedAt": 1779977800497,
+        "lastKnownName": "Sercioms",
+        "lifetimeStats": {
+          "wavesCleared": 42,
+          "matchesPlayed": 5,
+          "zombiesKilled": 212
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779977800497,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779977800497,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2804c1c6eca8531a6166769f2ed45c17aace5d8e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780146656365,
+        "lastKnownName": "Habon",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 20
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780146656365,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780146656365,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2b57bb58acab8e3246bfd3054fcf4301c4746328": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779472393741,
+        "lastKnownName": "Krzysztof",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779472393742,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779472393742,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2ae9070b029d05d8e6516aec0475002c53595a9d": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1773410650209,
+        "lastKnownName": "adigitaltati",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 3,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1773410650209,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1773410650209,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2ac7c93f5275f0174f100bebe93758b92f958179": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779910258616,
+        "lastKnownName": "Kyoi",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 45
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779910258616,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779910258616,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2cd9d0d012ca934141a8ee68be359e5749e56f9f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779802232852,
+        "lastKnownName": "Matt",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779802232852,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779802232852,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2b6d2d8cd70b5e9548e87f871d4642e0d6387cd7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1777644850031,
+        "lastKnownName": "bevyboy",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1777644850031,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1777644850031,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2d3f92c128ea4c4a93305d660f1be74a4b92245c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780770305642,
+        "lastKnownName": "Gustavo",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780770305642,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780770305643,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2da44b28f3873cce3711757bb5a9601ec3a279f7": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780250105288,
+        "lastKnownName": "willlnerd",
+        "lifetimeStats": {
+          "wavesCleared": 10,
+          "matchesPlayed": 1,
+          "zombiesKilled": 238
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780250105288,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780250105288,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2dba21f171c03c93d273564556b282b70ebf4d45": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780055915788,
+        "lastKnownName": "Fabio",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 43
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780055915788,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780055915788,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2d47604d37c9eaffa185e9762eda523772cb3398": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779818501987,
+        "lastKnownName": "0x2d4760",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 42
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779818501987,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779818501987,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2ed17fe87d700f552347a5b3639aa765828d7174": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778521483028,
+        "lastKnownName": "wolf",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778521483028,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778521483028,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2eee9cd183ac4021ac02764b7bb5d1a8a6695285": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779999407961,
+        "lastKnownName": "MANUZINHA",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779999407961,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779999407961,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2e06380a3575c710a778f8a98c787c958329c7ad": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779455422821,
+        "lastKnownName": "Iris Raveneye",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 26
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779455422821,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779455422821,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2f1388bcf2f5fc6e94147d525a2ca92ea93a0ca3": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780445229032,
+        "lastKnownName": "bryan",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780445229033,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780445229033,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2f90dd909abc0622593b93b5a34f8574c41bd924": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780263632823,
+        "lastKnownName": "prain 24",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 2,
+          "zombiesKilled": 63
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780263632823,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780263632823,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x2f12ac2680b4f3a60805344a2ad2645f73750e2f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780343834846,
+        "lastKnownName": "Tanvir13",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780343834846,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780343834846,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x30e215d1b4e36531efdbcac65d98d6607f4a2e0e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780161464483,
+        "lastKnownName": "thealex",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780161464483,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780161464483,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x304eaa9beaed5108a0528748f0bf893398c4a783": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780166145226,
+        "lastKnownName": "ELM87",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 72
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780166145226,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780166145226,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x313d2a2e869acb93207b90dda03f412eb65db2d9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779425675156,
+        "lastKnownName": "PepeGawd",
+        "lifetimeStats": {
+          "wavesCleared": 16,
+          "matchesPlayed": 1,
+          "zombiesKilled": 417
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779425675156,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779425675156,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x31f5697a1fe56abf632836807559dbcdae08d0bc": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779909926944,
+        "lastKnownName": "0x31f569",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 2,
+          "zombiesKilled": 88
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779909926944,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779909926944,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x316c9668384ddb682c97f665c42bcbb0e46c4fd1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780965218555,
+        "lastKnownName": "kevin",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 4
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780965218555,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780965218555,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x32ea98071d4956223bd8c77cfef926713645ba32": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778786153503,
+        "lastKnownName": "Rhada",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778786153503,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778786153503,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x33a7d139955c1b34033fa5187d752af986eace9e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780483407444,
+        "lastKnownName": "Cansy",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780483407444,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780483407444,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3365d0d045de808f835fca07bcef70350b1a317b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781336523249,
+        "lastKnownName": "kainos",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781336523249,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781336523249,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x337076185910c2a37097bf33ab162729834ed1f8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779724774655,
+        "lastKnownName": "Mana",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779724774656,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779724774656,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3426dcc7929e345803c033f90c725b488850d576": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780398503603,
+        "lastKnownName": "Jackson",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 1,
+          "zombiesKilled": 90
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780398503603,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780398503603,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x352da2e3fb03256e4e490ba0eaf22904df812e4f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780900086147,
+        "lastKnownName": "sanka",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780900086147,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780900086147,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x34b33867e5f6a5cc0e857f6a567f26d35b212a6c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779793573841,
+        "lastKnownName": "arctic",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 24
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779793573841,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779793573841,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x35cb125d2e6dea856fdb489874307db3d831dbf1": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780416347709,
+        "lastKnownName": "soyMischa",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 61
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780416347709,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780416347709,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x358c8856e8241dd2046dafce2c13a142eaf94366": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778761506819,
+        "lastKnownName": "Abhay",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778761506819,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778761506819,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x362832ac6dfe9ea372bb9d9cebaafc6a2cf9954a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779982065854,
+        "lastKnownName": "R0MAN",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779982065854,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779982065854,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x37eb77d838f922b5b30668359e22a206e2056c28": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779847601115,
+        "lastKnownName": "Talia Voidblade",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779847601115,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779847601115,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x380ffd35a92217bddac3a1f67a0f20eaaf805f1b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781033597946,
+        "lastKnownName": "Ozgunsami",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 54
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781033597946,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781033597946,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x37c3de27b59e38a5eb50e8cb4d609c8cdf81ce42": {
+      "profile_v1": {
+        "gold": 4,
+        "updatedAt": 1778753310453,
+        "lastKnownName": "matielmisticgg",
+        "lifetimeStats": {
+          "wavesCleared": 52,
+          "matchesPlayed": 11,
+          "zombiesKilled": 865
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778753310453,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778753310453,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x38980bd7cb56e347bd583141c05b6839eb6e55c1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780454234386,
+        "lastKnownName": "CratozZero",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 31
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780454234386,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780454234386,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x38953748c9b1dbdf793911265827a1d5c189f349": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779548206557,
+        "lastKnownName": "Dark",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779548206557,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779548206557,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x381465b3e738ee304618523b13106aa3e7d730ce": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779895147737,
+        "lastKnownName": "luan47163718477",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 3,
+          "zombiesKilled": 70
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779895147737,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779895147737,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x397a49760e060b130d0540637ae2181ef23db6e6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780241907547,
+        "lastKnownName": "lipe",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780241907547,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780241907547,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3910d0e9dc7f2f874a9074d5421248ba9b957742": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781326498387,
+        "lastKnownName": "Matt",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781326498387,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781326498387,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3984c22a56fc904e5dfd0cc6d36876cb09608c20": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780807963569,
+        "lastKnownName": "iram",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 144
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780807963569,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780807963569,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3bbc34e25280dc207847f93d2d4f3ae4863135bf": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778288422396,
+        "lastKnownName": "beng53",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778288422397,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778288422397,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3aee16d4613468d5a9926e1a982f168e5370a469": {
+      "profile_v1": {
+        "gold": 5,
+        "updatedAt": 1781216567322,
+        "lastKnownName": "Ponter",
+        "lifetimeStats": {
+          "wavesCleared": 47,
+          "matchesPlayed": 7,
+          "zombiesKilled": 1038
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781216567322,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781216567322,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3b77ff95aac5c32bfa199f1315c4e4fc3dfada81": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778390627080,
+        "lastKnownName": "Jabin Bezalet",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 37
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778390627080,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778390627080,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3c4942f882d0854b896207325b4625f7c680371a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780309952831,
+        "lastKnownName": "Riven Nightwing",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780309952831,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780309952831,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3c599805c742d0d034a57c96693e06fb0b4944f6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779983967104,
+        "lastKnownName": "fysszwcudduwkcx",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779983967104,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779983967104,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3c3501e8a921cc25d50c34f82080d24fb4ee988f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780317189910,
+        "lastKnownName": "sombra",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 7
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780317189910,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780317189910,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3ca1d868e2257dd8691e65574c26a2b33306dc2b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780575234041,
+        "lastKnownName": "Rez",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780575234041,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780575234042,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3d04eb6157197623f42b33d88f894f309f5baaba": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778377531212,
+        "lastKnownName": "OGBUILDER",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778377531212,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778377531212,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3cf7b89db9e0672a3246020ac1ba040ffd1168a1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780911054053,
+        "lastKnownName": "AJAY",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780911054053,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780911054053,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3d49b67250cba490fe0b515af1e188ce267caeb7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780459624907,
+        "lastKnownName": "Luis Gustavo",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 11
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780459624907,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780459624907,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3d0ea0e0458db51976795ac50edee2347f3203ec": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780143733084,
+        "lastKnownName": "Khai the trader",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 2,
+          "zombiesKilled": 87
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780143733084,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780143733084,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3d453c8204733737eb30c4c6763d73cdce04e277": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779657373598,
+        "lastKnownName": "amari",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779657373598,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779657373598,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3d6b0524212983497643af89479a73079330566c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781198441649,
+        "lastKnownName": "Laskar",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781198441649,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781198441649,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3da2e9e41ba03e9b7e979e1082b165410f0f0246": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779476566133,
+        "lastKnownName": "davidograu12494",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 41
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779476566133,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779476566133,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3d84c4a27d3d345b6b26d120d37dc014b2c7a48b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779995177199,
+        "lastKnownName": "Burbakis",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 47
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779995177199,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779995177199,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3e94e02b5c4c74048da696d918377344f47618a2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779462263809,
+        "lastKnownName": "Kai Firebrand",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779462263809,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779462263809,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3db5100b0d19e120043017a185f2e4aad9d39351": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1779698721043,
+        "lastKnownName": "Nene",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 1,
+          "zombiesKilled": 276
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779698721043,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779698721043,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3f6b1d01b6823ab235fc343069b62b6472774cd1": {
+      "profile_v1": {
+        "gold": 106,
+        "updatedAt": 1780789467332,
+        "lastKnownName": "MetaRyuk",
+        "lifetimeStats": {
+          "wavesCleared": 804,
+          "matchesPlayed": 77,
+          "zombiesKilled": 14957
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780789467332,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2",
+            "gun_t3"
+          ],
+          "tier2": [
+            "shotgun_t1",
+            "shotgun_t2",
+            "shotgun_t3"
+          ],
+          "tier3": [
+            "minigun_t1",
+            "minigun_t2",
+            "minigun_t3"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t3",
+          "tier2": "shotgun_t3",
+          "tier3": "minigun_t3",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780789467332,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x3faacc4e4287b82ccc1ca40adab0fc49a380b7ab": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1779457234290,
+        "lastKnownName": "Skat",
+        "lifetimeStats": {
+          "wavesCleared": 23,
+          "matchesPlayed": 7,
+          "zombiesKilled": 166
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779457234290,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779457234290,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4079ee2b089fb2d4ecc744f34731449665f4113f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779991717410,
+        "lastKnownName": "YULIFRIATNA",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779991717411,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779991717411,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x40d5e559c1c86e212fa0c3e8b3015501108dd38f": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780671645160,
+        "lastKnownName": "maycom",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 2,
+          "zombiesKilled": 63
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780671645160,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780671645160,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x416f9b1be9326f00d5db4efd9840861c3f10cf1b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779688532740,
+        "lastKnownName": "0x416f9b",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779688532740,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779688532740,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4123282cf01ff00d31ce2834863dd266a2fe6806": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779317289596,
+        "lastKnownName": "Mike Jones",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779317289596,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779317289596,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x41d9b68777b1e8655c8023423f8bd139cd91a645": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780044963201,
+        "lastKnownName": "VAC3",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 38
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780044963201,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780044963201,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4262ff8c7dcfd526898ad7ab9f250f046423ae13": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778590713507,
+        "lastKnownName": "Talia Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778590713507,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778590713507,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x434cc5f76b048662b8895a3a7137dfa78074be1d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780080113967,
+        "lastKnownName": "JustNormalP",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780080113967,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780080113967,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x438a2fa427bccdfd3cc91c7cab35484f7a6034cb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778426084231,
+        "lastKnownName": "Aria Sunflare",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 10
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778426084231,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778426084231,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x440575857e008ca1b7a7e36d58f48f043a14c255": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780111335632,
+        "lastKnownName": "Mukesh Kumar",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780111335632,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780111335632,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x439e5de700bf8f66ed46d17e4ae536210b18bd83": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778277691810,
+        "lastKnownName": "hamster",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 38
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778277691810,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778277691810,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x43c901d7e490d680550700f549aaa3abf1833e6e": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1773410650209,
+        "lastKnownName": "TatiOnAndroid",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 2,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1773410650209,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1773410650209,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x446a58c96426a69bbe0f40aceee3b50d52187ef3": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780140389972,
+        "lastKnownName": "NHAT",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780140389972,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780140389972,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4407c38a4758714f0248dc557f3f920dc2c87dcf": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780619106905,
+        "lastKnownName": "SHOCASE",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 67
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780619106905,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780619106905,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x44bf617346681f1cf166ed0d99d2765b038cb34e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780877752740,
+        "lastKnownName": "jpgamer20179",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780877752740,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780877752740,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x44a302d6df9561d3d9e895926968189266a9bd22": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780611634347,
+        "lastKnownName": "Pacorro2026",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780611634347,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780611634347,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x450b4bd41ca8b5b6cecd32845fd6420e341329ce": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780634660146,
+        "lastKnownName": "franco",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780634660146,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780634660146,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x44d6a10d3334e77a39d6d9fd95e6b5c3b070cd22": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781189688462,
+        "lastKnownName": "darknes666",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781189688462,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781189688462,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x456051c4721ac8635bf28a8df1cb002f0852afd4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779703268560,
+        "lastKnownName": "kamyh",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779703268561,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779703268561,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x454ff9c021f2baaab70595a7612f2689683549d1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780246804657,
+        "lastKnownName": "Dogmanyoutube",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780246804657,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780246804657,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x45b4b97e092518db94b69b51a437ff90d3ddf47c": {
+      "profile_v1": {
+        "gold": 4,
+        "updatedAt": 1780313081423,
+        "lastKnownName": "ZESE",
+        "lifetimeStats": {
+          "wavesCleared": 20,
+          "matchesPlayed": 2,
+          "zombiesKilled": 497
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780313081423,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780313081423,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x456494814f3b9f1467e0f9fb5a3fbf526784cb93": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780003993432,
+        "lastKnownName": "DESTRAIDO",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780003993433,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780003993433,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x45901941e71db8e3e71ae9730f1b487ed9db5e91": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780068694064,
+        "lastKnownName": "mahoraga",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780068694064,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780068694064,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4589bd3a7039e1cd3e39138f91fa97a2262080ae": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780066161734,
+        "lastKnownName": "arvin",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780066161734,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780066161734,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x46c286f93f75ebc093d7fe57fdd9222aa68a8ee2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780037433236,
+        "lastKnownName": "ania",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780037433236,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780037433236,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4767ae571cd68cfb2ed4dccda816d0fa4ce116fc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779745110622,
+        "lastKnownName": "Benjamin",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779745110622,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779745110622,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x47d05c3915411b23909f45efac2a20f529c80a29": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779604259556,
+        "lastKnownName": "HerKitsume",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 19
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779604259556,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779604259556,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x47a8619d01e5305211574486bf22bf0241cf5bc2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780761611023,
+        "lastKnownName": "mateo",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 14
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780761611023,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780761611023,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x47eeff8e1ce9229cfe73ec3e2a7cf80df05f627d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779801929936,
+        "lastKnownName": "Eris Nightwing",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779801929936,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779801929936,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x480bdc5fd6d8974809c4a1bf9df6c4b97b65f49b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781436007173,
+        "lastKnownName": "007",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 18
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781436007173,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781436007173,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4846ada37c751b4afc258aeb2f46861d9048a4dc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780548807807,
+        "lastKnownName": "rhyan",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780548807807,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780548807807,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4a7b71e34d81cf72a87b64fde52c857fb72d98fd": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780824515531,
+        "lastKnownName": "tiger 1",
+        "lifetimeStats": {
+          "wavesCleared": 13,
+          "matchesPlayed": 2,
+          "zombiesKilled": 136
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780824515531,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780824515531,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x49767c9dc4130ea4ac36f5757dc4f44c49d12b31": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779465484105,
+        "lastKnownName": "0x49767c",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779465484106,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779465484106,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x48fe8bd877b054478dfeb11ba1c4c56c084bdeeb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779672131046,
+        "lastKnownName": "TheWonderer",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 46
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779672131046,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779672131046,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4a47ca91ee9a075ff2d881aca32b84e6c1fa8b5d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779895271588,
+        "lastKnownName": "Arutouru",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779895271588,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779895271588,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x490825d4ed31d6d226f227cf3c74040e884fcf5d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780446733619,
+        "lastKnownName": "lotus",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 2
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780446733619,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780446733619,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4b02408b9b6a8c8e292972306500a3630dae4282": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779912915792,
+        "lastKnownName": "0x4b0240",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 28
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779912915792,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779912915792,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4cbdca8133172f770e5f6314d44d739a0ad9de33": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1772742676280,
+        "lastKnownName": "0x4cbdca",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1772742676280,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1772742676280,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4d7d384832a9b797090e287847bb7c20f5912e1c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779722346107,
+        "lastKnownName": "Heniakamiare",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 7
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779722346107,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779722346107,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4d92e89250328cc5bc9123c50e529a77fb8c4c9f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780256512339,
+        "lastKnownName": "prado",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780256512339,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780256512339,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4c067866b42ea3711735884b9480c9dfcd7f4bb1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780806578876,
+        "lastKnownName": "Branthony77",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 4,
+          "zombiesKilled": 123
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780806578876,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780806578876,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4cf48444704d1a6f1797c718ea5c40a53dbecc5b": {
+      "profile_v1": {
+        "gold": 6,
+        "updatedAt": 1780857624220,
+        "lastKnownName": "RAINBOWDASH1423",
+        "lifetimeStats": {
+          "wavesCleared": 27,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780857624220,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780857624220,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4dc2d81f254a8c37d3a062e1ebb6f84d0fcfc627": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780593634296,
+        "lastKnownName": "Asaf",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780593634296,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780593634296,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4ec895c6106ed3b23b08b5254a0ecc7b956a2387": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779627726366,
+        "lastKnownName": "kaio game42789",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779627726366,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779627726366,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4df4cece2d34c36ca3da7d215d9d69724786c52c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780084920966,
+        "lastKnownName": "linda",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780084920966,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780084920966,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4fd6e6e10c95f463b4b3e42fb12b68a6640f019c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779646165296,
+        "lastKnownName": "Jax Nightwing",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779646165296,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779646165296,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4e228b7da46c795858b5b8ac0edb5dc9c10fcc1c": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1778690827018,
+        "lastKnownName": "Vijay",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 3,
+          "zombiesKilled": 69
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778690827018,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778690827018,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x4f19e8cba9b64cdb93c3343653ca4b430ca0b698": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780101713633,
+        "lastKnownName": "x9",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780101713633,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780101713633,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x504b4d30137918f08f2cc1887d8fe0581c44bc79": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780857938495,
+        "lastKnownName": "Mellow",
+        "lifetimeStats": {
+          "wavesCleared": 9,
+          "matchesPlayed": 1,
+          "zombiesKilled": 180
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780857938495,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780857938495,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x523454eed57b8a0c4f53f17529d7da002b115a5f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779692718481,
+        "lastKnownName": "Ice",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779692718481,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779692718481,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5210936bd397b223c659e0ab82f49624bed89dde": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779780806444,
+        "lastKnownName": "Blaze Voidblade",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779780806444,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779780806444,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5306d27e0364960703eefdc52e9b7e92c9c6987a": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1778438940787,
+        "lastKnownName": "asuna",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 45
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778438940787,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778438940787,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x511a22cdd2c4ee8357bb02df2578037ffe8a4d8d": {
+      "profile_v1": {
+        "gold": 7,
+        "updatedAt": 1780665773808,
+        "lastKnownName": "ginoct",
+        "lifetimeStats": {
+          "wavesCleared": 38,
+          "matchesPlayed": 5,
+          "zombiesKilled": 160
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780665773808,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780665773808,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5228484dfedcd4a8b21953c213fa439e1e0bd7b0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780125403234,
+        "lastKnownName": "oliver",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780125403234,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780125403234,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x53083eefcda7ffcd37e744bb593f3ad42f912897": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780349017378,
+        "lastKnownName": "0x53083e",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 8
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780349017378,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780349017378,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x54e93609eb454a1f152edefdf022480794ce2130": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778440208197,
+        "lastKnownName": "Roustan",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778440208197,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778440208197,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x54d9d70a17e71b3e2c468a65e41b47308de4895d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780068962973,
+        "lastKnownName": "patito2408",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780068962973,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780068962973,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x53e22947510ad64ae85c96526bdbedb0b3e54f31": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781046526534,
+        "lastKnownName": "JaeName",
+        "lifetimeStats": {
+          "wavesCleared": 105,
+          "matchesPlayed": 17,
+          "zombiesKilled": 973
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781046526534,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1",
+            "shotgun_t2",
+            "shotgun_t3"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t3",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781046526534,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5402c78a2ab2b9d2d32ee390b77f6a123e9a7960": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779974385260,
+        "lastKnownName": "Laion",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779974385260,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779974385260,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x536c9bf5ff659c56df8149d980c1dd45396fdf39": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779628492512,
+        "lastKnownName": "felipe",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 18
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779628492512,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779628492512,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5529ca3c838621411d2ce0bcec1ba1e8822096a8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778698427727,
+        "lastKnownName": "0x5529ca",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 41
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778698427727,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778698427727,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x57d25818e39352de397d8a252c96f189135f08ff": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780501876755,
+        "lastKnownName": "HEMAN",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 58
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780501876755,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780501876755,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x57d1721f6223eb434e20f5b4a88e494008ea0542": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779548865416,
+        "lastKnownName": "PeterParkerWeb3",
+        "lifetimeStats": {
+          "wavesCleared": 32,
+          "matchesPlayed": 4,
+          "zombiesKilled": 553
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779548865416,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1",
+            "shotgun_t2"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t2",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779548865416,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x560090f9475fe6c625ad29ce43ec8ef706a1e564": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779881030799,
+        "lastKnownName": "0x560090",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 111
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779881030799,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779881030799,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x556f8b2d9ba4ac4eff8bfba582010b8b8fc0578f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780243000435,
+        "lastKnownName": "hxjhdd",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780243000435,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780243000435,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x565cb5ca67e374697e3da387f9cc901da32d08d3": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779582881246,
+        "lastKnownName": "ale",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 2,
+          "zombiesKilled": 60
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779582881246,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779582881246,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5854cce95d5e25817b41f4c41f06b695a83bc495": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779806022537,
+        "lastKnownName": "sebga",
+        "lifetimeStats": {
+          "wavesCleared": 16,
+          "matchesPlayed": 3,
+          "zombiesKilled": 80
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779806022537,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779806022537,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x58846529d9cdd34c4c6305094f78d829b4c2c187": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778377575245,
+        "lastKnownName": "KinGiki7",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 3,
+          "zombiesKilled": 78
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778377575245,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778377575245,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x598f8af1565003ae7456dac280a18ee826df7a2c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1773407695175,
+        "lastKnownName": "pablo",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1773407695175,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1773407695175,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5b310b6837a32da144355d63b4558b59d378393d": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780099101931,
+        "lastKnownName": "Hayabusa",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 73
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780099101931,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780099101931,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x58788e9d7254f2df309d94aa1f0173d446461cb3": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1778406606530,
+        "lastKnownName": "JewelryDing",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 55
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778406606530,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778406606530,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5aca3af61734cd4eca6a4ad496999340518a8143": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780231476647,
+        "lastKnownName": "fhfbrve e",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780231476647,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780231476647,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5bd8b9585f1c75373b5ffd8f731c143ec2c1816f": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780683863118,
+        "lastKnownName": "3LP1BE",
+        "lifetimeStats": {
+          "wavesCleared": 10,
+          "matchesPlayed": 1,
+          "zombiesKilled": 128
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780683863118,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780683863118,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5bbb6cc46b0b8ca91a5694a6c8ec49e716b1d0ef": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781196837973,
+        "lastKnownName": "0x5bbb6c",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781196837973,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781196837973,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5c8ce366e3861b5bd4ec8cf7018ee538bf4c97f7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1777642909177,
+        "lastKnownName": "pablo son",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 13
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1777642909177,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1777642909177,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5c8cbf24ea4d726b5ec27552ea97d1ce1fd40003": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780012797272,
+        "lastKnownName": "ehmw25",
+        "lifetimeStats": {
+          "wavesCleared": 12,
+          "matchesPlayed": 3,
+          "zombiesKilled": 177
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780012797272,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780012797272,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5d23fa5176f1d8b1ed2ae2a7bc7be244c7e4838b": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780248143764,
+        "lastKnownName": "dani gamer",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 63
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780248143764,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780248143764,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5cacbfdcf95d0c07fa9440672aff14b273092e9f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779221348127,
+        "lastKnownName": "0x5cacbf",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779221348127,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779221348127,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5d5aca4677a79e1390354e2e1de425ef5a0b131a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779911078936,
+        "lastKnownName": "Namo55",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779911078936,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779911078936,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5d5f884a604024237183ffe6fb62413f7d4ba877": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780753530251,
+        "lastKnownName": "Jax Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 43
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780753530251,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780753530251,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5f20a744f1f2db98fe96863f24cf916b1efcf31c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780371545889,
+        "lastKnownName": "LKSlice",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780371545889,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780371545889,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5da9d0ea94f8d06e44a2fea30144bdbb32e18a26": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779899900235,
+        "lastKnownName": "0x5da9d0",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779899900236,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779899900236,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5e7266952f6f68f5e6ee3665fb75fb678f0e5e8b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779895675242,
+        "lastKnownName": "Zahir  Nightsky",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779895675243,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779895675243,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5da0ae7b73fbdd0e17c74dd0ade9d356663f5096": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779849638105,
+        "lastKnownName": "0x5da0ae",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779849638105,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779849638105,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5f9498934bbe756bf7eb8b17747f89ed58075f2c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780023723664,
+        "lastKnownName": "AshMystiq",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780023723664,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780023723664,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x601f2fe1bcd147abd78c08a7804441c30326e2c4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780441932915,
+        "lastKnownName": "espanta biejas",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780441932915,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780441932915,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x5feb3c6e6679b1512376fb444ef5b99f954d212d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781115613969,
+        "lastKnownName": "haron",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781115613969,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781115613969,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6080d69a9f10950ad0191ee230f73f18cdbefcca": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780722025489,
+        "lastKnownName": "GraCastillo",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780722025489,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780722025489,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6200ef56817824c473938501929b703890ea3b72": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778362021402,
+        "lastKnownName": "Cosmo Delphin",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778362021402,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778362021402,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x608626810f56af9e10e8355e66d613f851c9f2c3": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780520056910,
+        "lastKnownName": "yfhtjgiyiygutuy",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780520056910,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780520056910,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6236b89a0b41117a365d570e31b98a2403355742": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781158604721,
+        "lastKnownName": "saysot",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781158604721,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781158604721,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6240ddbafdc6277cf0c219406ee30b4d3df77aad": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781230913230,
+        "lastKnownName": "X",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 52
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781230913230,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781230913230,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x62718f9f4ba0cc6d7bdd9139ab0643137d01978c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780061849257,
+        "lastKnownName": "Professor",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780061849257,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780061849257,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x643248693d8cd0d1282407d0322f2c42d03620fe": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780091381744,
+        "lastKnownName": "Iris Starfall",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780091381745,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780091381745,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x63a899be68ee6b3d73991084928bb56ba0b00ee8": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1780581784961,
+        "lastKnownName": "EibrielAndroid",
+        "lifetimeStats": {
+          "wavesCleared": 19,
+          "matchesPlayed": 5,
+          "zombiesKilled": 160
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780581784961,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780581784961,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x62f58ffb42e662990c7b31d0deb063c695dfbacc": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780904382825,
+        "lastKnownName": "sonic",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 2,
+          "zombiesKilled": 144
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780904382825,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780904382825,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x62bd11099260b3861c2da1418566c354e0cdfa65": {
+      "profile_v1": {
+        "gold": 6,
+        "updatedAt": 1779972606930,
+        "lastKnownName": "Yiffers",
+        "lifetimeStats": {
+          "wavesCleared": 36,
+          "matchesPlayed": 8,
+          "zombiesKilled": 333
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779972606930,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779972606930,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x65823ad3d12af95e00a4d60b90f3140bcb2a81c3": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780546359920,
+        "lastKnownName": "b",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 2,
+          "zombiesKilled": 88
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780546359920,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780546359920,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6488ce8099b95dd585b6c17d8a146b857de44d81": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780934449788,
+        "lastKnownName": "gael",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 33
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780934449788,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780934449788,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x66b1488a32e21f2d2757713d16facd9d25ec977c": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779696620905,
+        "lastKnownName": "BurnieRoots",
+        "lifetimeStats": {
+          "wavesCleared": 10,
+          "matchesPlayed": 1,
+          "zombiesKilled": 100
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779696620905,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779696620905,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x65c64d2c4d61434eeb6032fc5886f38c2abae4df": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779795330759,
+        "lastKnownName": "Voltigeur21",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 37
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779795330759,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779795330759,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x668ce912823c58aa643d44a22b6f8814ef37c853": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778462969363,
+        "lastKnownName": "Mgangster",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 4
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778462969363,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778462969363,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x665f2f318df794e0141a04c1e722011679f91ddb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779602580340,
+        "lastKnownName": "Bahamount69",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779602580340,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779602580340,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x66d844d651cfcc593663f003dd259d7812071b00": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1779989566938,
+        "lastKnownName": "Echo Stargazer",
+        "lifetimeStats": {
+          "wavesCleared": 12,
+          "matchesPlayed": 2,
+          "zombiesKilled": 163
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779989566938,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779989566938,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x670119bca514c9fa654653c7781d058a0e0e0b4d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779422528027,
+        "lastKnownName": "neil",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779422528027,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779422528027,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x675a02612b41b7908024167d1707e0a1dd2def39": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780860066721,
+        "lastKnownName": "Queen",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780860066721,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780860066721,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6723dcb07f3ca735223cd1c0acfa62dd994a1bb4": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1774012670021,
+        "lastKnownName": "ToxicMobile",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1774012670021,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1774012670021,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x67905236a1733cc974130389bfa1c38652aae775": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779494445371,
+        "lastKnownName": "0x679052",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 2
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779494445371,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779494445371,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6788772313bac0a4d7c4405cdaafc953c317a8c2": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1780049116419,
+        "lastKnownName": "Ember",
+        "lifetimeStats": {
+          "wavesCleared": 13,
+          "matchesPlayed": 1,
+          "zombiesKilled": 295
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780049116419,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780049116419,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x687e14a94200953d2e4548ab69bb1b43d3418a17": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780450804238,
+        "lastKnownName": "lele",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780450804238,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780450804238,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x67e40b88a8fc9fffb196c62d15a540e6fe182b8c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780699993679,
+        "lastKnownName": "Jonathan2404",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780699993679,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780699993679,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x69ae58e99617b2b0e83b2b75a112fc94376bb7a1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779492697874,
+        "lastKnownName": "owen",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779492697874,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779492697874,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x691de3d72288714008109fc201393361ea638e77": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780417287569,
+        "lastKnownName": "shamsdanish",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 36
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780417287569,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780417287569,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x69f17a023778bbaebfa1bc2bc098a5cebb86b9bf": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781036545770,
+        "lastKnownName": "Alana D Gasai",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 3,
+          "zombiesKilled": 147
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781036545770,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781036545770,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x69d5774a162e6595843f1c09e7be51c26f4f65af": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781418540341,
+        "lastKnownName": "alo",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781418540341,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781418540341,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6a77883ed4e65a1df591fda2f5252fd7c548f198": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779529615954,
+        "lastKnownName": "Drinks",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 77
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779529615954,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779529615954,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6a5df714dcabf28bd35aea0f2eecd95b2affedb2": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780300120934,
+        "lastKnownName": "AvatarOG",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 2,
+          "zombiesKilled": 99
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780300120934,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780300120934,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6d26ce1d93c8ba0e99a23be6b6ba1d80b53815ab": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780142896650,
+        "lastKnownName": "Iris Ironheart",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 34
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780142896650,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780142896650,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6bf753d9734c2a2515fe4cf5a19074865897bc19": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781219896440,
+        "lastKnownName": "Vega Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 56
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781219896440,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781219896440,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6ab0357e96284c182b9c1c6a776011d604ca921c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779475213137,
+        "lastKnownName": "Sofi",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779475213137,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779475213137,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6b670ca78b84a94f7cd46c2624412caef4722240": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780072491444,
+        "lastKnownName": "Ibrahim",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780072491445,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780072491445,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6cf78d64fa68f71ca800c10523fec7de533db781": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778290111061,
+        "lastKnownName": "0x6cf78d",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 57
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778290111061,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778290111061,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6d3b13bac3be8ee600a2f20c1e445bfd8efe20aa": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781439480510,
+        "lastKnownName": "M TIGER NO 1",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 28
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781439480510,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781439480510,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6e545c2e070fcee53b916d05495bfd42ddc62d5b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779926975938,
+        "lastKnownName": "0x6e545c",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779926975938,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779926975938,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6e178a42afd6ff23c86cea3f869045618928788a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780567264139,
+        "lastKnownName": "KarisMas",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780567264139,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780567264139,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6e52adc6eb8e4fba43a8109d559f68591e35bbb6": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780633994591,
+        "lastKnownName": "mrdeaht",
+        "lifetimeStats": {
+          "wavesCleared": 16,
+          "matchesPlayed": 4,
+          "zombiesKilled": 225
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780633994591,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780633994591,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6f395cb5ff248b7b5e877b959ab1078dd0f821cf": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779455450781,
+        "lastKnownName": "robtfm",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 2,
+          "zombiesKilled": 38
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779455450781,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779455450781,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6f4bf3dcfdafc92592689e2f66e4f86b09711ef3": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779517009275,
+        "lastKnownName": "Tobiasgamer",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779517009275,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779517009275,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x6f94db0e6cacf37d62cf59506ba0c4236f27b5e5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780591891996,
+        "lastKnownName": "alec",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 35
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780591891996,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780591891996,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x705f2043454610f41a4018e99cf6d91c019f09bf": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780892805147,
+        "lastKnownName": "Kai Ironheart",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780892805147,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780892805147,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x700ef540825b56bbd1306ac0a9ac1f15be8bc13d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780128187495,
+        "lastKnownName": "my name is god",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780128187495,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780128187495,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x700a6f849a639651cab05c3473f209d0133c38f4": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780665786186,
+        "lastKnownName": "Seba",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 1,
+          "zombiesKilled": 48
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780665786186,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780665786186,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x70d4db61bffc20fde27378d572f47f4a5b9f1e62": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779891296921,
+        "lastKnownName": "0x70d4db",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779891296921,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779891296921,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x711a29d2681bfa41a37e2a05293466bd566da087": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778603824052,
+        "lastKnownName": "pepolife2499",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 37
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778603824052,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778603824052,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x72709a4db0b14800c4ce2bd505d6f753895bd71a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779989813340,
+        "lastKnownName": "gg",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779989813340,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779989813341,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x71ea4a7252fc56f0bf25b6f71243a7f780d8e686": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779504290736,
+        "lastKnownName": "khanu",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779504290736,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779504290736,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x706f88546364e77a8d742817c739b033e725b881": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778776923254,
+        "lastKnownName": "Gabriel358",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778776923254,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778776923254,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7479f99d37c825ea2e5063dca557b772f5b1654b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780008059935,
+        "lastKnownName": "dinosaur",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780008059936,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780008059936,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x74300934d192b8701a510b8e6400ade90276b646": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779805020584,
+        "lastKnownName": "AFMaster",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 20
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779805020584,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779805020584,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x74cdcadfdc9d3651abdde532312fb99c38ec1033": {
+      "profile_v1": {
+        "gold": 10,
+        "updatedAt": 1780679804649,
+        "lastKnownName": "Habib12",
+        "lifetimeStats": {
+          "wavesCleared": 82,
+          "matchesPlayed": 23,
+          "zombiesKilled": 767
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780679804649,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780679804649,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x76fb4389fe67a400297057321208b0f7bb8d9c60": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781098019834,
+        "lastKnownName": "Mushman15",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781098019834,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781098019834,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x753ac7eede578474c47edeef157bcdff0ae8e72f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780085656361,
+        "lastKnownName": "Vega Starfall",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780085656361,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780085656361,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x75065938c24739af6cb82bc74725622fa2120de1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778428935175,
+        "lastKnownName": "0x750659",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 33
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778428935175,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778428935175,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x77d746dc4c9e2860fdde0ac3aa3c94bd719cf8b9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780757544310,
+        "lastKnownName": "fox",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780757544310,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780757544310,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x78169d208b6715d5a615292fe084a275a909e7c1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780021044574,
+        "lastKnownName": "0x78169d",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 21
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780021044574,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780021044574,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x78a5b3720c586c6f5fa15f8ab4b7a06c5daf61e7": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779547247621,
+        "lastKnownName": "Seren Nightsky",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 3,
+          "zombiesKilled": 149
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779547247621,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779547247621,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x78e1ecac87664bcdb04cfcc424e07822f74b4752": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780732757548,
+        "lastKnownName": "OdenSon",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780732757548,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780732757548,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x797520f471de8ec7b1e771e014149c4fd408367c": {
+      "profile_v1": {
+        "gold": 4,
+        "updatedAt": 1780005061849,
+        "lastKnownName": "FredElf",
+        "lifetimeStats": {
+          "wavesCleared": 99,
+          "matchesPlayed": 9,
+          "zombiesKilled": 1972
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780005061849,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2",
+            "gun_t3"
+          ],
+          "tier2": [
+            "shotgun_t1",
+            "shotgun_t2"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t3",
+          "tier2": "shotgun_t2",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780005061849,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x78cab3307e4bda64f5793b18383fadd8b51bec7a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780243184105,
+        "lastKnownName": "SwanBr",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780243184106,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780243184106,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x79ade416f521a6453f61a1dc0579a855ece546a9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780150364888,
+        "lastKnownName": "Olive",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 2
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780150364888,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780150364888,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x79ce347076f0abd40b9e51b485a909c08e6fbe05": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779980361650,
+        "lastKnownName": "tanjiro",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779980361651,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779980361651,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x79eba368f1a006de4321601196c051c965519708": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778383939358,
+        "lastKnownName": "riya",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778383939358,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778383939358,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7a051bd541e9246b4e45043a71b0a8fc939222c4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778794076649,
+        "lastKnownName": "Seren Raveneye",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778794076649,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778794076649,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7afbc4151bd4b4c09167c7dae053d469b71aeaa2": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780133808909,
+        "lastKnownName": "Zazi",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 55
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780133808909,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780133808909,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7aae6ddea5c57be90d85da9f3df8e4e9ef63ed3d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779635368865,
+        "lastKnownName": "Jax Voidblade",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 18
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779635368865,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779635368865,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7b739b21e7b2fb627ccecdb288a1dc7d72210692": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778278099625,
+        "lastKnownName": "SebaBevy",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778278099625,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778278099625,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7b1050997d5afb2709e7ad89080192ee04bfa7ed": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780869151382,
+        "lastKnownName": "frunk35",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 48
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780869151382,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780869151382,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7b790d8c86fbf45787b5c3bc1c2ef8c94fadf7de": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1779787444866,
+        "lastKnownName": "0x7b790d",
+        "lifetimeStats": {
+          "wavesCleared": 9,
+          "matchesPlayed": 2,
+          "zombiesKilled": 86
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779787444866,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779787444866,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7ddffd08aabb24aa75fa9c6067289154832c6ace": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780244257309,
+        "lastKnownName": "iguanazoxD",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 10
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780244257309,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780244257309,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7d4f814d79b982961aeaf5dc5eeb480ca7ac373d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779633923715,
+        "lastKnownName": "myk",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 29
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779633923715,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779633923715,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7e9ae3da0a6018ffda933ad6252668884572a56d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781022285587,
+        "lastKnownName": "tanjiro",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781022285587,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781022285587,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7bbea9c18cd0541acab8c19da2b11d0c03faef1c": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780526260647,
+        "lastKnownName": "AlGoreRhythm",
+        "lifetimeStats": {
+          "wavesCleared": 18,
+          "matchesPlayed": 2,
+          "zombiesKilled": 251
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780526260647,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780526260647,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7d6f20368c0ae25480c037148847f6e5dd30b12c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780224680073,
+        "lastKnownName": "Nova Firebrand",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780224680073,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780224680073,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7b9f3541fb4e9f9c3b01b4395959ef26f5dd3be6": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780899781277,
+        "lastKnownName": "Baatar",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 2,
+          "zombiesKilled": 144
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780899781277,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780899781277,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7f08150697f0a1ffe010b66b00ef5f3a7b43d07e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780940851342,
+        "lastKnownName": "j wick",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780940851342,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780940851342,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7e92e84b50320658e37f5b3d0b24ae0e77c99495": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1774012090484,
+        "lastKnownName": "hukasu",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1774012090484,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1774012090484,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7f09f2e1234c1c63e61a247a0b7eb6d474b2c2d2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779689123242,
+        "lastKnownName": "lukinhagf",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779689123242,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779689123242,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x80b93791a6827a6730cda41b4e29287a08b6959a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780262005638,
+        "lastKnownName": "Alex",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780262005638,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780262005638,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x7fb56a42659995e86a05625977b8cf6c26e8c821": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780897371467,
+        "lastKnownName": "benysyahputra",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780897371467,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780897371467,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x81ca5b0b79fd194b6d7911d54764f54d9db74b4d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781101293471,
+        "lastKnownName": "Max",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 39
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781101293471,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781101293471,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x82e7eabd0a4a60dccf3b50a0090fc4129e94b868": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780078625333,
+        "lastKnownName": "xeran",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 58
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780078625333,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780078625333,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8218a2445679e38f358e42f88fe2125c98440d59": {
+      "profile_v1": {
+        "gold": 11,
+        "updatedAt": 1779941114377,
+        "lastKnownName": "Noob",
+        "lifetimeStats": {
+          "wavesCleared": 329,
+          "matchesPlayed": 34,
+          "zombiesKilled": 4495
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779941114377,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1",
+            "shotgun_t2",
+            "shotgun_t3"
+          ],
+          "tier3": [
+            "minigun_t1",
+            "minigun_t2",
+            "minigun_t3"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t3",
+          "tier3": "minigun_t3",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779941114377,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x831fa4b60b39047b3cbc13e815a341d6f25e6142": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1772742703759,
+        "lastKnownName": "0x831fa4",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1772742703759,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1772742703759,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x83f5ed8b5e01402e408d132a46443e4d11e47c26": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778637924218,
+        "lastKnownName": "miz",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778637924218,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778637924218,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8494407fe562fe7c491e1bd090cdaa98b51026f6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779728924098,
+        "lastKnownName": "Ravena",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 53
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779728924098,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779728924098,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x848206edce319e40bee4528a1a0070607822007d": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780845657391,
+        "lastKnownName": "Jabol",
+        "lifetimeStats": {
+          "wavesCleared": 21,
+          "matchesPlayed": 4,
+          "zombiesKilled": 195
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780845657391,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780845657391,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x84a22f41ce4490b7f15ad45330f2986a6acc9a0f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780716768467,
+        "lastKnownName": "Andersonzoka22",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 45
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780716768467,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780716768467,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x858343382132b9ab46c857a7d52fdbafc039f784": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1775827932787,
+        "lastKnownName": "Zino",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1775827932787,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1775827932787,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x84fb0ff9e9e978d8eb4bdac8b59a87214cf47532": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779997091917,
+        "lastKnownName": "ANUPADAKA",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 2,
+          "zombiesKilled": 55
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779997091917,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779997091917,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x85fd3fbc46dd53c49927ea242efac0af8f88b311": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779725877572,
+        "lastKnownName": "asdasdasd",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779725877572,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779725877572,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8665cc604cefc97180533ac32c9d383c676a13a7": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780046287737,
+        "lastKnownName": "Vansh",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 3,
+          "zombiesKilled": 155
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780046287737,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780046287737,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x86a7608c1690907955405c7ac7444d85c76f4a71": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780181730368,
+        "lastKnownName": "xdx",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780181730368,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780181730368,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x86c17354b7af70cd2aabe8a7020d6dd58644272b": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780345575240,
+        "lastKnownName": "selcuksenturk#272b",
+        "lifetimeStats": {
+          "wavesCleared": 14,
+          "matchesPlayed": 2,
+          "zombiesKilled": 191
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780345575240,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780345575240,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x87383a6f8f894213bd9d5704d23810f1c2733251": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778293477608,
+        "lastKnownName": "Anos",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 33
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778293477608,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778293477608,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x897d519d6da9565b3b855e4fa01ca863c83221b6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780477713131,
+        "lastKnownName": "Axel Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780477713131,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780477713131,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x86e8562bdbf8958fc9d126f1c41149a6b68bc0d1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778582423039,
+        "lastKnownName": "0x86e856",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778582423039,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778582423039,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x89991fb710fc1a3342bc05467660a860ad708d8d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781028209964,
+        "lastKnownName": "lugil",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781028209964,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781028209964,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x87c38f75a31daf5b863bae1bae3755763abf9ec9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779692668008,
+        "lastKnownName": "jejedsl 46 1010",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779692668008,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779692668008,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x89c1d88ecbb02b19c77f80e99ded6151eddd5e63": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779599602679,
+        "lastKnownName": "N",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779599602679,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779599602679,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x89c773c9558cf132d02a371a5b55019351ae5ca9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780035146941,
+        "lastKnownName": "Kristina",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 34
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780035146941,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780035146941,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8b0a83b011c82da36ed1274d6beb3816aaa67116": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780086460577,
+        "lastKnownName": "Cleylton1029132",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 20
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780086460577,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780086460577,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8adea5b455ff3e6a36b27827302d475ac68c0417": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780259950726,
+        "lastKnownName": "Rolkksando",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780259950726,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780259950726,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8a84a44aa73bb862f90482b7656504beb5029406": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778574091383,
+        "lastKnownName": "Wallet 3",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 2,
+          "zombiesKilled": 67
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778574091383,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778574091383,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8b309d4e4406fb4d920b90559063b04f9ace8d60": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781038000096,
+        "lastKnownName": "ZairaV",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781038000096,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781038000097,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8b4209e512811b4fc1635154acaf6ee408e24df0": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1774012509142,
+        "lastKnownName": "casla",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1774012509142,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1774012509142,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8d13ae50e6a195b1efd824bbf9698d416de38c7e": {
+      "profile_v1": {
+        "gold": 5,
+        "updatedAt": 1781096257330,
+        "lastKnownName": "YmitY",
+        "lifetimeStats": {
+          "wavesCleared": 28,
+          "matchesPlayed": 6,
+          "zombiesKilled": 434
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781096257330,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781096257330,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8c94dfb21834f744a77aa2f8a6eef2832b4feb23": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780178828566,
+        "lastKnownName": "Theo Gomes 123",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780178828566,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780178828566,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8d18f5959dd0117aa2966af9f11e3c4760907205": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779649587142,
+        "lastKnownName": "Martinolis",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779649587142,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779649587142,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8e1c588c32135bdd1df43b6fa96d2271fe984ba5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780905793125,
+        "lastKnownName": "Stuvok",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780905793125,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780905793125,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8d6ea5d674a65e5db6f49d5e51943d5bfd45e7cf": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779965142573,
+        "lastKnownName": "0x8d6ea5",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 2,
+          "zombiesKilled": 119
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779965142573,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779965142573,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8e5430ee40a381874c538fa8fe4362ba54bf6dd8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779808634146,
+        "lastKnownName": "kiwis",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779808634146,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779808634146,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8e3370ba67d64c6532f5e02b7b1f5eddad05721d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780347462139,
+        "lastKnownName": "jayrichmoney",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780347462139,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780347462139,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8e7a38d61691e3e4eb6fc78b1b57a20ff8e2e826": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780758579009,
+        "lastKnownName": "eik77693",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 26
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780758579009,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780758579009,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8ee07fa714f3dfc8b9be299fc961d10306d07d72": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779476397327,
+        "lastKnownName": "Aster Ironheart",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779476397327,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779476397327,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8e8b1aae7b157b0888e3388f08f42f40923880c9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780258346257,
+        "lastKnownName": "alejoo",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780258346257,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780258346257,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8fe3c2f4ed4796ae50af7b5164355f637f9b1502": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780493341760,
+        "lastKnownName": "luffy gear 5",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780493341761,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780493341761,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9054404d92b7085c2b56e290ab2b45207e0cae44": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778417848365,
+        "lastKnownName": "bree",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 4
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778417848365,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778417848365,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x8e535e856f634b570e780d204fe0bc1812c5efc2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778540638849,
+        "lastKnownName": "jack",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778540638849,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778540638849,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x903c3a8326f4e9cbc983509ac38792d780269a3f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780031863439,
+        "lastKnownName": "0x903c3a",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780031863439,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780031863439,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9089b3614acb4a5233ba84a1b84048b8d48d7838": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778765875901,
+        "lastKnownName": "TrapaTrupa",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778765875901,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778765875901,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9057101bdc70d711474ddbc5374a1ad9396bbb19": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780589636062,
+        "lastKnownName": "Lyra Frostborn",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 2
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780589636062,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780589636062,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9258773f75f12e05a450aad154e34856a6a897c5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780843008190,
+        "lastKnownName": "kuzume",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780843008190,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780843008190,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9305a0d65b0435d2fdd53e26e6120df744e92532": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780258329177,
+        "lastKnownName": "sayuki30",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 59
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780258329177,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780258329177,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x922f930a06802431f8b0e73c168285f33f58e405": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779566762642,
+        "lastKnownName": "TOMMY",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 23
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779566762642,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779566762642,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x910b8d15790aeb437bad544c49628e013b7c3140": {
+      "profile_v1": {
+        "gold": 4,
+        "updatedAt": 1780980772899,
+        "lastKnownName": "Losss",
+        "lifetimeStats": {
+          "wavesCleared": 19,
+          "matchesPlayed": 2,
+          "zombiesKilled": 370
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780980772899,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780980772899,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x933a93d6ac8fd37ee6b0b7e096c6dd25f82b223a": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780319558930,
+        "lastKnownName": "Jax Nightsky",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 29
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780319558930,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780319558930,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x942520f59cdadc7bdd8dc8a7f8a99414b7c3539f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779556275354,
+        "lastKnownName": "Catchy",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779556275354,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779556275355,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x932388351ff48caf0ee3f21561111cdff11ce66e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1777642725401,
+        "lastKnownName": "iOSWaifu",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1777642725401,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1777642725401,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x95513a69b27009a3ca9b5b2014da975150116fd9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779317468894,
+        "lastKnownName": "ohdearcrypto",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779317468894,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779317468894,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x948558921559133ce635b9c3d048f4b1f20aac4b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779063962090,
+        "lastKnownName": "Coco",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 18
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779063962090,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779063962090,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9565c5395fa48349fc7398bca4479938296c6fee": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779258319724,
+        "lastKnownName": "Nontoxic321",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779258319724,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779258319724,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x95f657eeaa3cbd0b02d189b6dda4653b111f84f6": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780948828880,
+        "lastKnownName": "f",
+        "lifetimeStats": {
+          "wavesCleared": 9,
+          "matchesPlayed": 6,
+          "zombiesKilled": 60
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780948828880,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780948828880,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x956ae649b3a6adba4311e69fb69059bef34c8f8c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779908787543,
+        "lastKnownName": "0x956ae6",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779908787543,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779908787543,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x967806277927e2dc3ded8e5caca302620606bcc6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780890294738,
+        "lastKnownName": "johny",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780890294738,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780890294738,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x960e9032e405108bd4a6fdb20f3daff9a435beb1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780033860817,
+        "lastKnownName": "Drake Galewind",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 14
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780033860817,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780033860817,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x96e04700a252d18e7fb4bf208a0717b8271e359e": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780656897873,
+        "lastKnownName": "draka",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 64
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780656897873,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780656897873,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x972365bc475496ebc4c3b4aa827d42957cc27732": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780445970331,
+        "lastKnownName": "Zane Skyforge",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780445970331,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780445970331,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x97244f5de9ca6824782435417f55d17d8b777e8a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779990043163,
+        "lastKnownName": "l3lackD",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 41
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779990043163,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779990043163,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x97f849ceffd0bb21a41bc0bbff8d65208c755c4c": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780514833203,
+        "lastKnownName": "GRUMPY",
+        "lifetimeStats": {
+          "wavesCleared": 10,
+          "matchesPlayed": 1,
+          "zombiesKilled": 114
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780514833203,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780514833203,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x97b653dd0ccfad00fd181a27093a6bab41aff85e": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780710083987,
+        "lastKnownName": "Mehran",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 83
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780710083987,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780710083987,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x95818ff9c1b62bdf36182164abdb227561e9ddd4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780443313534,
+        "lastKnownName": "Gabriel 827",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780443313534,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780443313534,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9a2149de3bd4fa9be0654a6d3d8d9c2628ab5be6": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780658147204,
+        "lastKnownName": "Ikenga28",
+        "lifetimeStats": {
+          "wavesCleared": 13,
+          "matchesPlayed": 3,
+          "zombiesKilled": 145
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780658147204,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780658147204,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x991c26b43b8be44554601f09cba245354717f6df": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780166743299,
+        "lastKnownName": "alexander frede",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780166743299,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780166743299,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9a09de5ad6855cc06bc346206c79afa1429d8f91": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779982415475,
+        "lastKnownName": "miguel",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779982415475,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779982415475,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9ad45c6ec74b940b585983e64e706107f34e27ae": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781118442854,
+        "lastKnownName": "prtk96",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 40
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781118442854,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781118442854,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9a91c60c5b211848d1a0ea8e6383bb2edb59b62f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781284474951,
+        "lastKnownName": "Baly",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 2,
+          "zombiesKilled": 50
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781284474951,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781284474951,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9a5c44032d56732404acdaa803c939796f8503be": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779781560830,
+        "lastKnownName": "Keegan1120",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779781560830,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779781560830,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9ae55bf5797d49a2d36889bc8510a351e121df49": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779763976073,
+        "lastKnownName": "joao",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779763976073,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779763976073,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9bbad5c6b99ae0a6c04fa63a85a9c8901e6e76da": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779466093979,
+        "lastKnownName": "Dinja",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779466093979,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779466093979,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9ae18882c1bd0e5cc43ee2dac4b3170bf256ad89": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780041515443,
+        "lastKnownName": "deems",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780041515443,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780041515443,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9d8c39d51668e2cb9b31811efdd8a1da99414657": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780037177170,
+        "lastKnownName": "PlayUp",
+        "lifetimeStats": {
+          "wavesCleared": 12,
+          "matchesPlayed": 2,
+          "zombiesKilled": 166
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780037177170,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780037177170,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9bf528b4150543ea213a4da7c216a87e0892c521": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780278412851,
+        "lastKnownName": "Aiko",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780278412851,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780278412851,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9cb0d44ee1dad61cf3f4d5e1550c4edb25a704b8": {
+      "profile_v1": {
+        "gold": 5,
+        "updatedAt": 1780059639730,
+        "lastKnownName": "Agus mobile",
+        "lifetimeStats": {
+          "wavesCleared": 35,
+          "matchesPlayed": 17,
+          "zombiesKilled": 503
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780059639730,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780059639730,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9dcfb9f02d3bcb7efb02c37fa43196ded0045e24": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780404647349,
+        "lastKnownName": "tarik06tarik06T",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780404647349,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780404647350,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9eb4b2a73e7aaea11c0d4b17f6a6a2f028a48568": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780199683753,
+        "lastKnownName": "Steve u",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780199683753,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780199683753,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9e66660b39b9d553bde0feeab9792352459cb4b4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780017934577,
+        "lastKnownName": "FernwehY29",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780017934577,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780017934577,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9f031ec9b0c5c089b8c32d4c473130f9f9713d28": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779692245525,
+        "lastKnownName": "loloanfr",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779692245525,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779692245525,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9f2eedf4def9da6f5f367b8f1aacdbe622145654": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779577341801,
+        "lastKnownName": "alkilany",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779577341801,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779577341801,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9eed63a160d7a1be920bfe0e87efc911ca83b20b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779996812035,
+        "lastKnownName": "Nat",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 46
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779996812035,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779996812035,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0x9fe4ec56f50dba681efeb744f6e65767593318bf": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778598873747,
+        "lastKnownName": "Lee MeadowLion",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 33
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778598873747,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778598873747,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa1c5d20464eeaa8a0f89df2b1641fcdd7aff5d50": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779640965059,
+        "lastKnownName": "Ravyn Blackrose",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779640965059,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779640965059,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa116203faad4de81a28d2aab1357f0c342ee0653": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780498123349,
+        "lastKnownName": "lakepeter",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780498123349,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780498123349,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa20936751e082bd2e7adaf6e63580b3d54c04dc1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779492647433,
+        "lastKnownName": "Pocahontas",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 31
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779492647433,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779492647433,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa284a2f689d00e404915107a29f9fa7101cdb343": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779831504767,
+        "lastKnownName": "0xa284a2",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 57
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779831504767,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779831504767,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa1debbcd83ed8d77ed2829910cf30d504bb6e69d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778435373195,
+        "lastKnownName": "enr12",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778435373195,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778435373195,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa2acfac4c5c63a0ecc3a1e392faa840f43fee281": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780393450541,
+        "lastKnownName": "DinhoSA",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780393450541,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780393450541,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa2cce7c0751657f302fa94ed4560acb5d364f45c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779875771051,
+        "lastKnownName": "tonuzzzz#f45c",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779875771051,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779875771051,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa2e6b1986542bafb05767860cf80854aefa40451": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780265620952,
+        "lastKnownName": "Kael Stargazer",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 13
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780265620952,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780265620952,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa31d4ef5b7472a6391c0bca5d562ef32180c7b42": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778343009995,
+        "lastKnownName": "Makbul ali",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778343009995,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778343009995,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa38f6a768b00c5b48b8c9522fa8f500203620e29": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780414551508,
+        "lastKnownName": "mafin",
+        "lifetimeStats": {
+          "wavesCleared": 41,
+          "matchesPlayed": 7,
+          "zombiesKilled": 387
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780414551508,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780414551508,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa39f1e26ef4e673c1200995db52e8ad0ca86b5ad": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1772820981566,
+        "lastKnownName": "0xa39f1e",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1772820981566,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1772820981566,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa3b6bf8e32bade06bf46967c62a0283bbf0e19ec": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779488825661,
+        "lastKnownName": "Mateus",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 10
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779488825661,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779488825661,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa459249a9df90c7ccd8546702d635f2d058e2f21": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780150947820,
+        "lastKnownName": "Miguel",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 28
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780150947820,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780150947820,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa3da52a194b487ed0bea91ff7658a8806608542f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779845245195,
+        "lastKnownName": "0xa3da52",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 39
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779845245195,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779845245195,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa4fe5ae07b33ca246757e747bedc6575f1b07fda": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1780073031090,
+        "lastKnownName": "ALFA",
+        "lifetimeStats": {
+          "wavesCleared": 25,
+          "matchesPlayed": 3,
+          "zombiesKilled": 332
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780073031090,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780073031090,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa6f50d902db39417830103c80c9b7b9ad484708f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781193355410,
+        "lastKnownName": "a",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781193355410,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781193355410,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa76a666c9d32c32ebb9304142ba7fb0658e72e53": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780556037959,
+        "lastKnownName": "InvisibleUser66",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780556037959,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780556037959,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa73165208f40b284a4cdb9fdc9341ba4acaedce4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780226081654,
+        "lastKnownName": "Mauricio jj",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780226081654,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780226081654,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa866b26e06aa46c138aa50f0a3e56443d1d083d4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779539242218,
+        "lastKnownName": "eoek",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 21
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779539242218,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779539242218,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa79c826ce542c1b0a7c085f22b1850d691e98fdf": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779850955279,
+        "lastKnownName": "0xa79c82",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 37
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779850955279,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779850955279,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa8c000a300d386aba3451d8bcb0d0c2a262ec8d9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779441863291,
+        "lastKnownName": "Emmanuel",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779441863291,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779441863291,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa8a3168ada432653f5339028086c1deb68ea066c": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780671402143,
+        "lastKnownName": "Cryptony",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 63
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780671402143,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780671402143,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa988612376214e731de1d2cbe9c16515374caeb2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780401633866,
+        "lastKnownName": "Luvlee17",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780401633866,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780401633866,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa8ff684318913a92b896c698f3b2f40ab7f0a317": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779814181743,
+        "lastKnownName": "0xa8ff68",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779814181743,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779814181743,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa9b53fc2bf01c33a93688872ce66da063ffeab96": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779819904234,
+        "lastKnownName": "0xa9b53f",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779819904234,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779819904235,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa99b435cfd028a88b81bed436f3f2eaa9bbbd1e1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780597959780,
+        "lastKnownName": "jhjjk",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 13
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780597959780,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780597959780,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa9b5ef4060ddf797c2e9eaeb2aa6bb9160ff65a9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780044200129,
+        "lastKnownName": "prashanth 95423",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780044200129,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780044200129,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xa9c664209ef70624b2076b9b97705d6df87dd574": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780512653236,
+        "lastKnownName": "Wallally#d574",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780512653237,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780512653237,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xaa09c1d2e7cd7ab65bd2836be38679cbeb631629": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780152449641,
+        "lastKnownName": "carlos",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 37
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780152449641,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780152449641,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xaad631bef42bc9132cc55f5211d923e0e706133a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780490526051,
+        "lastKnownName": "Rune Starfall",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780490526052,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780490526052,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xab601445da55935dc9bed70d3cc60af9966fdbf3": {
+      "profile_v1": {
+        "gold": 12,
+        "updatedAt": 1780052736299,
+        "lastKnownName": "thatmf",
+        "lifetimeStats": {
+          "wavesCleared": 44,
+          "matchesPlayed": 3,
+          "zombiesKilled": 75
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780052736299,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780052736299,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xaad95b4b788bf77679f36157ba946788ec366145": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781425602672,
+        "lastKnownName": "thumbi",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 1,
+          "zombiesKilled": 51
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781425602672,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781425602672,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xab6b9fd9fb1b23e73ba41594d64a4c93ec0c9812": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781186371968,
+        "lastKnownName": "tyy",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 8
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781186371968,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781186371968,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xabe2506afb4396a9ba3b4932077cca427ee75950": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780023589102,
+        "lastKnownName": "0xabe250",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 19
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780023589102,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780023589102,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xac7bbd6fc4cfa2c00aa0656208d6a243b9023ddc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780797028544,
+        "lastKnownName": "porra",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780797028544,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780797028544,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xaca66034161d0637c872a511eb960f741a2f39be": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780267222735,
+        "lastKnownName": "roru1312",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780267222735,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780267222735,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xad76f39820e7c5ae064211298fe7e4065f621f58": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778479183207,
+        "lastKnownName": "Maforio123",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 2,
+          "zombiesKilled": 72
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778479183207,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778479183207,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xad4a28cbc1a434ab0640a7d445679f7290e6b302": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779656863791,
+        "lastKnownName": "n la casa de mi",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779656863792,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779656863792,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xae6ff5e8b2d7b6db1f1c9803ac1740cb1f784d22": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780355410656,
+        "lastKnownName": "kid0bengalazoas",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780355410657,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780355410657,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xadd29d1a5c313108b034f4b1e0be717bff464d8b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781030630536,
+        "lastKnownName": "Ramotcho",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 7
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781030630536,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781030630536,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xaeafee8d2daf9962984edcd445ff773c7a7eaf3b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780159448261,
+        "lastKnownName": "Rita",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780159448261,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780159448261,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xaf087f2a033a4b5b6120091a8673367c839cadd3": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780415796538,
+        "lastKnownName": "JR",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 67
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780415796538,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780415796538,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb01cc205105c546253c6abe0c63a47243566238a": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781350766584,
+        "lastKnownName": "krokokos",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 2,
+          "zombiesKilled": 97
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781350766584,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781350766584,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xaf4b1403cde00576fd0828ebc31d931533ee1639": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780014936757,
+        "lastKnownName": "Z4ck925",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780014936757,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780014936757,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb04f6a5ba7c92e6f18444339e443c52eeb676278": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780018955802,
+        "lastKnownName": "FernwehY209",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 125
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780018955802,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780018955802,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb01f6f973a94724e9719abb24c8b9844d479b752": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780801911329,
+        "lastKnownName": "itsmariel",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 18
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780801911329,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780801911329,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb0df04fd46e8ae5549194748cdacb1a75e6f0c57": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780980581344,
+        "lastKnownName": "renaenae12",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 67
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780980581344,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780980581344,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb073915e42645efbe3dd881a542f3dd78641122f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780044637564,
+        "lastKnownName": "BabyMan18",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780044637564,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780044637564,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb3517222d0afbb6119d6fc058c021fd1360d4d97": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779886360062,
+        "lastKnownName": "0xb35172",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779886360063,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779886360063,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb2226381c4c97a118d09ec118e8ebe4462258cb4": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1781255169553,
+        "lastKnownName": "Chui",
+        "lifetimeStats": {
+          "wavesCleared": 32,
+          "matchesPlayed": 8,
+          "zombiesKilled": 457
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781255169553,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781255169553,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb455cd3b2ce27b62aca280742a49488ceb53459d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779869581534,
+        "lastKnownName": "0xb455cd",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779869581534,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779869581534,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb43f2e6031b88faddf7cf82d90bac84f7cab2971": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780124330940,
+        "lastKnownName": "cruzman",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780124330940,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780124330940,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb48f94686e4daa04adf95392a98c73f98f3696ce": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781264445589,
+        "lastKnownName": "Sajad",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781264445589,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781264445589,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb5c62465ea514544405f6099e8dc5b134bd043b5": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779911966123,
+        "lastKnownName": "0xb5c624",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779911966123,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779911966123,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb61f3c2677b1bf7f55b58ff79483505ffab2378e": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780065224165,
+        "lastKnownName": "Ken",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 1,
+          "zombiesKilled": 76
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780065224165,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780065224165,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb70c3a4939345f3ebb5099c17b2f41ae67b4424f": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780244098288,
+        "lastKnownName": "Igsydman24",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 38
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780244098288,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780244098288,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb5ee243eaa08f02595da77f713d2dc5139bd07f4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780044911235,
+        "lastKnownName": "RoCKy",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780044911235,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780044911235,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb63bf2900cd7e3ad97c56f01773449e14bb438ab": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780183808442,
+        "lastKnownName": "Iris Sunflare",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 17
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780183808442,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780183808442,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb62cdfd3ba0426f661cf63be8066d4010f92a174": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780849213786,
+        "lastKnownName": "Jobe",
+        "lifetimeStats": {
+          "wavesCleared": 13,
+          "matchesPlayed": 2,
+          "zombiesKilled": 240
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780849213786,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780849213786,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb6827d72112cc88e529fce0ca6ddad192c5d91ce": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778543659498,
+        "lastKnownName": "0xb6827d",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 38
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778543659498,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778543659498,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb781e1520d69211170060f9ce4fbf7579b920b37": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779737650450,
+        "lastKnownName": "0xb781e1",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779737650450,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779737650450,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb777f78713ee2073d8f74f4e50a4146eb61db1be": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780732483736,
+        "lastKnownName": "Taha",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780732483736,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780732483736,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb6662b789398165a12cd528fc5b76d22350f0a18": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780089742035,
+        "lastKnownName": "t6rtyrrtuyt",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780089742035,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780089742035,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb7b32a2e85cad6c03a444c88b95f0ca12e5f0360": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780664086381,
+        "lastKnownName": "jhulio",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 20
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780664086381,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780664086381,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb7abb4490e0b90b88c2032ad95a4915df384af86": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781411762659,
+        "lastKnownName": "Logan",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781411762659,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781411762659,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb838d02f7f7a32a47be8a85386a79b83194f9ce3": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780276945322,
+        "lastKnownName": "0xb838d0",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 2,
+          "zombiesKilled": 106
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780276945322,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780276945322,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb9374ae58a80c1e964550a6e1249aa68edc72562": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1778390322369,
+        "lastKnownName": "Ajay kashyap",
+        "lifetimeStats": {
+          "wavesCleared": 27,
+          "matchesPlayed": 11,
+          "zombiesKilled": 293
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778390322369,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778390322369,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb8c4df381c6c305758f806c3aa71f37aabbcbd92": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1773409664017,
+        "lastKnownName": "boedo",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1773409664017,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1773409664017,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb84c4688549076f2d95e77d9cc7e932d41b92331": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780411821959,
+        "lastKnownName": "sidx",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 48
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780411821959,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780411821959,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb981adf92358c9b164925d230871915fefbbc8f1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779390484151,
+        "lastKnownName": "Jhon",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 2,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779390484151,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779390484151,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xb97abccec84db73fc193e5968c73e41dcd681a49": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780238157650,
+        "lastKnownName": "LEAN",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780238157650,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780238157650,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xba07fd3a0954f87bfc83676d68886d624cad96b8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780774683131,
+        "lastKnownName": "BONES",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 51
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780774683131,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780774683131,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbabf140c3523ec751879b21f0f3fe8c80e8cc8a0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778424851207,
+        "lastKnownName": "Turroncitoto",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778424851207,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778424851207,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xba814f5f2722dedfa461713dcc1a80461024841c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780171379236,
+        "lastKnownName": "SanFederico",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780171379236,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780171379236,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xba2813235f654d1b02eae458ab5dfef289962866": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780072101983,
+        "lastKnownName": "Echo Nightwing",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780072101983,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780072101983,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbb3131b2b85e364f67b53024111a3b5f29b08e6e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778913897403,
+        "lastKnownName": "kanon",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778913897403,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778913897403,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbac8dd98dc8c5564aa0f8bcb42403ba3f977ef53": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780764514478,
+        "lastKnownName": "davi Jesus Jesu",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780764514478,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780764514478,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbb386105ea6ab08cbca829eafdd0a93e7a9a5ccc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779733820846,
+        "lastKnownName": "LuMan",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779733820846,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779733820846,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbbc4f57b6354b0f4d837f622ce4fb8aaec17eccb": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780684932810,
+        "lastKnownName": "Neoarx",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 42
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780684932810,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780684932810,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbbdd969913cfbaf2a02c2e1a202f61e51f172ecb": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1781185816035,
+        "lastKnownName": "Seba iOS",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 3,
+          "zombiesKilled": 48
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781185816035,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781185816035,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbbd2a170cd12f444a37cffe8c038ded6f988448c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781159763140,
+        "lastKnownName": "B",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 55
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781159763140,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781159763140,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbca07512fe47d630ed79e454db1196fdd3b98c71": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780867657914,
+        "lastKnownName": "Marco",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780867657914,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780867657915,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbc1e21c289294f6889c1e1f710fadf41282e17df": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780168546837,
+        "lastKnownName": "Caua15026",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780168546837,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780168546837,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbcab836420dbd94dd95e1dfd6cf1c7587423eaef": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1778689110008,
+        "lastKnownName": "Blaze Skyforge",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 62
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778689110008,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778689110008,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbd0f9a7b392604bab4e150d14ab56e5076d0e762": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779509763132,
+        "lastKnownName": "Untold",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779509763132,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779509763132,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbd80035d0499aacb7e52ebab94026a6412706f5c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780466365497,
+        "lastKnownName": "rian",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780466365497,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780466365497,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbd4ca44b02e2962f62cd38f3ca3eb11726ae6502": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780458738751,
+        "lastKnownName": "Rabin chhetri",
+        "lifetimeStats": {
+          "wavesCleared": 10,
+          "matchesPlayed": 3,
+          "zombiesKilled": 76
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780458738751,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780458738751,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbedb39a30ac86de35f3284e4ccd228e08ac261d9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779688079846,
+        "lastKnownName": "teambrandom",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 2,
+          "zombiesKilled": 43
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779688079846,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779688079846,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbd9d7977b84892818ee258d90c8fa65f46a9edea": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1779455525570,
+        "lastKnownName": "Elzath",
+        "lifetimeStats": {
+          "wavesCleared": 12,
+          "matchesPlayed": 2,
+          "zombiesKilled": 42
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779455525570,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779455525570,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbf2416782169f647f55536422d0f6de78880dc71": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780039710139,
+        "lastKnownName": "Jordan",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780039710139,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780039710139,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xbfe1c02f5e3848b98b2af83d5f83ba14e9844014": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1774012147072,
+        "lastKnownName": "ginoctMobile",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1774012147072,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1774012147072,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc0155ad929af907b67b32838f42a21dd96f0da2c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780189131038,
+        "lastKnownName": "Luis",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780189131038,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780189131039,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc0b2f495ddcd68d784a1726959cdb3be137c1e38": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780745414944,
+        "lastKnownName": "bhagyashree",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780745414944,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780745414944,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc0c784bbed947b255518c0a17c40456057c42cc5": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780258581400,
+        "lastKnownName": "Decentralandia",
+        "lifetimeStats": {
+          "wavesCleared": 18,
+          "matchesPlayed": 2,
+          "zombiesKilled": 280
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780258581400,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780258581400,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc15665e479fa573e2ca9d075a615dd3205c7ac83": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780950369572,
+        "lastKnownName": "Rune Ironheart",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780950369572,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780950369572,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc174c6b5253bcdae5523a4294b459e8a6bcf44a1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778347100530,
+        "lastKnownName": "Rund1699",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778347100530,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778347100530,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc199a0b108f5db9db382701eab09bc28b5921634": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780578029703,
+        "lastKnownName": "Cleo",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 55
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780578029703,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780578029703,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc2c9bce152d9790aa3c3c6abefb63a1e55e308cb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779732209966,
+        "lastKnownName": "Talia Raveneye",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779732209966,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779732209966,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc1fc4a94af8ac60df3667deb45a83f1896bb17d2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1776955742650,
+        "lastKnownName": "Eve",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1776955742650,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1776955742650,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc2c9c6cbea1d8c94889549844f6d7cc5fe1b68ff": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780122769500,
+        "lastKnownName": "KINGHELLKAT",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780122769500,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780122769500,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc382adc986d1c97ea1c9266962aba0029401eadd": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780446853634,
+        "lastKnownName": "0xc382ad",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780446853634,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780446853634,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc40cd255532757116d61208e45f391b72a68d49c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780046411249,
+        "lastKnownName": "Zara Nightwing",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 3,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780046411249,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780046411249,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc57addf51728ff5935c02f5728710477d6d2baf6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780807684749,
+        "lastKnownName": "pilt",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 5
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780807684749,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780807684749,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc502975b49398f9754afc4e9693cf0e1594f3275": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779973166325,
+        "lastKnownName": "thecodingcave",
+        "lifetimeStats": {
+          "wavesCleared": 13,
+          "matchesPlayed": 5,
+          "zombiesKilled": 189
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779973166325,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779973166325,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc5413efa0adeb27952afc9c5358063a9229bc8dd": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779688809461,
+        "lastKnownName": "zhen",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 44
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779688809461,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779688809461,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc61244fdc8fb4f11725bf4e35d2e56833ad1f623": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780763425114,
+        "lastKnownName": "mpilo",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 26
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780763425114,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780763425114,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc5f271e5981cec3428bb84e0e0720d51b0a489bd": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780084280434,
+        "lastKnownName": "lamb",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780084280435,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780084280435,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc63f242465a004ea7a969bcb12fdc1efe212fe67": {
+      "profile_v1": {
+        "gold": 6,
+        "updatedAt": 1778604188280,
+        "lastKnownName": "MATIIIIIII",
+        "lifetimeStats": {
+          "wavesCleared": 26,
+          "matchesPlayed": 4,
+          "zombiesKilled": 392
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778604188280,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778604188280,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc8cf2642836d774d70e199f09beacfe829a0f7a1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779921337478,
+        "lastKnownName": "0xc8cf26",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779921337478,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779921337478,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc885017cbc2d8e0a4445df1fef8ec68377acf961": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779455526518,
+        "lastKnownName": "MateoFromApplee",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 3,
+          "zombiesKilled": 31
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779455526518,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779455526518,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc7a0e720822a81f0c448950e07630a907ad3d0ff": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780734855639,
+        "lastKnownName": "GatoNegro",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780734855639,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780734855639,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc91f38ece15571d166d0e6a5e1451f0416eb1e9f": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780515910237,
+        "lastKnownName": "gilang",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 58
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780515910237,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780515910237,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc99ba5e8def11d8223dc4690f66fef2fbe9ce2c9": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1778476924818,
+        "lastKnownName": "Aromatic ladd",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 73
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778476924818,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778476924818,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xc9bfc842ccebba4f18fba9a71637a1d70d2e6f74": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1778508431872,
+        "lastKnownName": "Thane Raveneye",
+        "lifetimeStats": {
+          "wavesCleared": 34,
+          "matchesPlayed": 4,
+          "zombiesKilled": 531
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778508431872,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778508431872,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xca74cab43d09fe0c8af55222870d139c7f262605": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779993619523,
+        "lastKnownName": "gojo",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 20
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779993619523,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779993619523,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xca2e16dc8277cc59887573d23d58d20473134327": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779682626236,
+        "lastKnownName": "shadow",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779682626236,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779682626236,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcafd854708c1f231bc814cab16e748fe0ec6a73c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781053307079,
+        "lastKnownName": "liljon814",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781053307079,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781053307079,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcb876093e8aa2cab99c474e549778b78ca4eb10d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781435121066,
+        "lastKnownName": "amiratco3711",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781435121066,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781435121066,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcb1963c1eaef7a41a74abcc19ecf8b31cd80f603": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779717045736,
+        "lastKnownName": "Cael johnson",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779717045736,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779717045736,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcb8b2aba4db7da875f6a10b472ebf17da419d6de": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780340119007,
+        "lastKnownName": "unmanolete",
+        "lifetimeStats": {
+          "wavesCleared": 16,
+          "matchesPlayed": 3,
+          "zombiesKilled": 8
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780340119007,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780340119007,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcbdc864eda5e25cd6feba6616b7adc1af71ff94e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781528079878,
+        "lastKnownName": "agusc",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 6
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781528079878,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781528079878,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcbcc2f62bbd2d82c03e64ef31e45db6a5c47647e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779646161027,
+        "lastKnownName": "Junaid Khan",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779646161027,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779646161027,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcbe43e58d9d5020d817bfa11474206d96ad00f67": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781131033086,
+        "lastKnownName": "NoNameMi",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 2,
+          "zombiesKilled": 145
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781131033086,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781131033086,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcc2621f8a1974d50631c85922f2b921867a397e1": {
+      "profile_v1": {
+        "gold": 4,
+        "updatedAt": 1779627838783,
+        "lastKnownName": "JimSedric",
+        "lifetimeStats": {
+          "wavesCleared": 25,
+          "matchesPlayed": 3,
+          "zombiesKilled": 219
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779627838783,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779627838783,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcc5fa6a539dcb1d8dfb509ac3736924b9de1646c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781060078112,
+        "lastKnownName": "Matias2026",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781060078112,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781060078112,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcc7ec1663907abc7f7a7027bffa03da38751d9ad": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780164804534,
+        "lastKnownName": "Dyv",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 1,
+          "zombiesKilled": 57
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780164804534,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780164804534,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcd11f65ef202716f2fa8201901f117b22cb1d6ef": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779989588028,
+        "lastKnownName": "robleis",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779989588028,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779989588028,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcc6d01ba3a967cdc1c53cae55bb350b14661f5b9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779545273344,
+        "lastKnownName": "emir",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 9
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779545273344,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779545273344,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xccab25e6d2be00b446be0be93b78a602f7eb1d97": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780231757683,
+        "lastKnownName": "Neo Voidblade",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780231757683,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780231757683,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcd9afe0375e06b4c23031c0a81324bc5320dd501": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780599326948,
+        "lastKnownName": "Alezzz",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780599326948,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780599326948,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcd87e8af2cd513a49990a249dc2e021ef5043f17": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780549824449,
+        "lastKnownName": "PSV",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 7
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780549824449,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780549824449,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcda3c8121f4e8658702bee7e96b72aa01b2af314": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780522580485,
+        "lastKnownName": "sandor",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 55
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780522580485,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780522580485,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xce5e13b7980bdd1407b2d872b60440dd511feff7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780231422054,
+        "lastKnownName": "ThommyDark",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780231422054,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780231422054,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcdee1467430a16adb67497418662eb2763a3c056": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1780933107284,
+        "lastKnownName": "Ryuk",
+        "lifetimeStats": {
+          "wavesCleared": 18,
+          "matchesPlayed": 3,
+          "zombiesKilled": 198
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780933107284,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780933107284,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xce890a906ae24d323f7a139667f7055b0fc09413": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780367182194,
+        "lastKnownName": "Illusiddous",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780367182195,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780367182195,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xce97f247ba5ad5d25e93cd6995a28ce205acf6c0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779692695289,
+        "lastKnownName": "Gato feo",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779692695289,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779692695289,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcecfe80641b0fbaba7d8a0cb30d78a16eee9af97": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779832794762,
+        "lastKnownName": "PinkPantherG197",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 108
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779832794762,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779832794762,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcea556b9f9444663e168f25785fdf8538fb629b2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778597656894,
+        "lastKnownName": "D4NNY",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 40
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778597656894,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778597656894,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xced431050a36f4e938250da71c74e206407e7538": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779665344733,
+        "lastKnownName": "Waxine",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 6,
+          "zombiesKilled": 127
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779665344733,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779665344733,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcf0edec609c086a4927183c6b5af7cafdd998fdc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780584033646,
+        "lastKnownName": "Aster Skyforge",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780584033647,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780584033647,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcf854f17da5b236f3e01fb384a331f408ae2c2ab": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781177578112,
+        "lastKnownName": "BroccoliGC",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 33
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781177578112,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781177578112,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xcfd8d8f88a5ad81bf51a140d633f0c509fde9638": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780305583255,
+        "lastKnownName": "jokowi",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780305583255,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780305583255,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd00349af05f1cd4d35e560d3b91726ff78293e76": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780081292254,
+        "lastKnownName": "Echo Dawnblade",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 12
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780081292254,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780081292254,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd00c2a265af9536c3237fd0a0ae3d281164d4b41": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1779922882408,
+        "lastKnownName": "Levi",
+        "lifetimeStats": {
+          "wavesCleared": 18,
+          "matchesPlayed": 3,
+          "zombiesKilled": 175
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779922882408,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779922882408,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd05109c64e6995e42d294f4e651b9ccb0c1115ef": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780636343678,
+        "lastKnownName": "junio",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780636343678,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780636343678,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd04ce56b853992d8cc553e57a8e947424fdc7ee3": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779895466770,
+        "lastKnownName": "lurajo",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779895466770,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779895466770,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd0def5113c21705dba7cddc88d8a9d6549ea6313": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779812281886,
+        "lastKnownName": "0xd0def5",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 36
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779812281886,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779812281886,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd074f9d33e9fbdb3437f5d85077379d88200aae2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781532805872,
+        "lastKnownName": "Boobala421",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 14
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781532805872,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781532805872,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd102f4b2697a855804ded574422b2de85b20d7a0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781154430985,
+        "lastKnownName": "Juan Carlos",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781154430985,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781154430985,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd13aee4255c08cbe219bcee2875ce3adf9fb8572": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779973267548,
+        "lastKnownName": "Velzard",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779973267548,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779973267548,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd1b2d3fbfdddaf77f512858995cea6843cbed1fe": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781366167828,
+        "lastKnownName": "Serhio",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 46
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781366167828,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781366167828,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd29e682b378692b753bf5f45abc2e1bf72136e13": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779875651301,
+        "lastKnownName": "miletich",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 35
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779875651301,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779875651301,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd2b1116d2eac248b267bb51cc96c1b035d73d9e7": {
+      "profile_v1": {
+        "gold": 6,
+        "updatedAt": 1780320201857,
+        "lastKnownName": "RimuruT",
+        "lifetimeStats": {
+          "wavesCleared": 27,
+          "matchesPlayed": 2,
+          "zombiesKilled": 409
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780320201857,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780320201857,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd2a57a996f610e8a8589b53bd758e2289abb0574": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779733553755,
+        "lastKnownName": "Nicollas Jack",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779733553755,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779733553755,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd436a3eea068bf26ba27832f8f5e829c4781df29": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1776716226991,
+        "lastKnownName": "betroyal",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1776716226991,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1776716226991,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd340f300465e6f8c3ba4bb4286bd84ebe7f1d2ec": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780239433504,
+        "lastKnownName": "sally",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 1,
+          "zombiesKilled": 45
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780239433504,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780239433504,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd483aeb65c7d38733d8b23986b983841a5650a4c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781419672168,
+        "lastKnownName": "Adamshawn",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781419672168,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781419672168,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd493dd4ff85a984520dcc1686bc345fb587031eb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780473891346,
+        "lastKnownName": "Frost",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780473891346,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780473891346,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd4ffd7af4aa62f62c07342bd2ae64d98fe81c2ac": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779770211484,
+        "lastKnownName": "0xd4ffd7",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 40
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779770211484,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779770211484,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd4c955d2701fbb27ef34c06f14a0148c66d131bc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779720382491,
+        "lastKnownName": "ANITA",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779720382491,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779720382491,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd5cef985ab75363223ed554b79c1d75b67688620": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779706286841,
+        "lastKnownName": "ZinThuAung 86",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 2
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779706286841,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779706286841,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd5254bf25570b0f5c7959adeb18be2eb50f1a520": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780233773579,
+        "lastKnownName": "Oliver",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780233773579,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780233773579,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd653d4183f88b30bf00b5857de4050b4b6630055": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781186727129,
+        "lastKnownName": "annys",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781186727129,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781186727129,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd6876819c7c9134855a620be08cf661ce599cfb3": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779497926771,
+        "lastKnownName": "kukangkukang",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 42
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779497926771,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779497926771,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd5e17572e1bdaee82830d3f6f836f30aa20b5e46": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779981933393,
+        "lastKnownName": "0xd5e175",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 24
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779981933393,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779981933393,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd6eff8f07caf3443a1178407d3de4129149d6ef6": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779503699038,
+        "lastKnownName": "Canessa",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 2,
+          "zombiesKilled": 33
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779503699038,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779503699038,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd7376fef66c8294831a349771f3e9093d44cf399": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780561801566,
+        "lastKnownName": "Zane Galewind",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780561801566,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780561801566,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd74bab1df0c20675c2dfe6dcd42033c8ce535a1a": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1779519599987,
+        "lastKnownName": "iyan07",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 2,
+          "zombiesKilled": 45
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779519599987,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779519599987,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd7ff26d269971143c4460376db48e275b32169fa": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780637095231,
+        "lastKnownName": "HORUS",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 33
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780637095231,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780637095231,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd8166f3e3cbbb70fb7ec78ad4238ec7a440c1ef4": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1779455382258,
+        "lastKnownName": "SomethingTOTEST",
+        "lifetimeStats": {
+          "wavesCleared": 16,
+          "matchesPlayed": 5,
+          "zombiesKilled": 183
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779455382258,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779455382258,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd82d005e8f8d5385db40ba23884a5c967bb1e8af": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1779429003272,
+        "lastKnownName": "AlanHowick",
+        "lifetimeStats": {
+          "wavesCleared": 14,
+          "matchesPlayed": 2,
+          "zombiesKilled": 264
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779429003272,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779429003272,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd8b1ea57a22085eb1731c891b19d1e237493a38a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779646202388,
+        "lastKnownName": "TheKoalaKing",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 2,
+          "zombiesKilled": 35
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779646202388,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779646202388,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd8560278045aebe11b56af4b64499d3e650b3b77": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1779131696073,
+        "lastKnownName": "0xd85602",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 1,
+          "zombiesKilled": 242
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779131696073,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779131696073,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd8f86bfadf4da3f7aeb0547a7c080cef0f6cfb7a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781234421102,
+        "lastKnownName": "Sonarutendo",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 13
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781234421102,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781234421102,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd98141d360601a5dba40fd824b4d0b1996689780": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780548549688,
+        "lastKnownName": "Leonardo",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 19
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780548549688,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780548549688,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd9b16b53ee42eb63ffd02d6707a6b2263fb6fac7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779634570754,
+        "lastKnownName": "Alandi",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 52
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779634570754,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779634570754,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xda3b7e51da23ffc417e76b3fd4901f5232210ac4": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779645854310,
+        "lastKnownName": "valentina",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 4
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779645854310,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779645854310,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xd9b8625dad9574448119e410005f37672903c492": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780229494552,
+        "lastKnownName": "Burnbunny",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780229494552,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780229494552,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xdb59c6eb8c0760f60602a6ab66adcad6eb48477c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780645218564,
+        "lastKnownName": "Maninder",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780645218564,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780645218564,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xdb614471a87b0101c9cc67431085417f95c08903": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779987859764,
+        "lastKnownName": "Kogama",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 29
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779987859764,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779987859764,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xdb87bc4416198be5858b61e5d15585df7420609e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779985516145,
+        "lastKnownName": "Vega jacks",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779985516145,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779985516145,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xddb57cc46375c3f819cb8639638f5466b4a75aa5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780363793102,
+        "lastKnownName": "Echo Skyforge",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780363793103,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780363793103,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xde1cb7232d9a48120b68368f0ec1b30900e291ac": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778637098138,
+        "lastKnownName": "0xde1cb7",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778637098138,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778637098138,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xddf0e06b3b52eb6d081c5e76be6d9879fe8d6a1b": {
+      "profile_v1": {
+        "gold": 18,
+        "updatedAt": 1780320013580,
+        "lastKnownName": "Stephy",
+        "lifetimeStats": {
+          "wavesCleared": 90,
+          "matchesPlayed": 11,
+          "zombiesKilled": 1206
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780320013580,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780320013580,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xde4a369271f2d15a421d19844c81b73c554114b9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778342642142,
+        "lastKnownName": "0xde4a36",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778342642142,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778342642142,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xdef3b69df0439ca6c8418fbbf11deecef82a2faf": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780811178825,
+        "lastKnownName": "SeniorGiggles",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 40
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780811178825,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780811178825,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xdf40c3757f26804efa4e649059072ab51bdbfa7f": {
+      "profile_v1": {
+        "gold": 4,
+        "updatedAt": 1779455512635,
+        "lastKnownName": "EibrieliOsApple",
+        "lifetimeStats": {
+          "wavesCleared": 20,
+          "matchesPlayed": 4,
+          "zombiesKilled": 59
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779455512635,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779455512635,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xdf693801ed9dd9c29316d33126c3e9b35ff57f10": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780013949860,
+        "lastKnownName": "Roux",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 21
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780013949860,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780013949860,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xdf8f6023eed1495dd39e94b32e0b181c67cabe02": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1775828133762,
+        "lastKnownName": "manolo",
+        "lifetimeStats": {
+          "wavesCleared": 12,
+          "matchesPlayed": 1,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1775828133762,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1775828133762,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe1946823532c8bf25c7afc49a2d1cdd7c9bee2de": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780017008242,
+        "lastKnownName": "TayGod23",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780017008242,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780017008242,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe2ba28b8acfb981c1e0fa97f36fc6e91b4b66997": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780327491067,
+        "lastKnownName": "gojo",
+        "lifetimeStats": {
+          "wavesCleared": 8,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780327491067,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780327491067,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe1bcbfc26ce3aaf8353c0ae036e3741fe22e7ef5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779732752162,
+        "lastKnownName": "Axel Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779732752162,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779732752162,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe2bf74026444dc7748465736104c614fad6227bc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1772627940299,
+        "lastKnownName": "0xe2bf74",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1772627940299,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1772627940299,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe3602381ec109492380daaff16c8dc90ea0d44b7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779485433260,
+        "lastKnownName": "0xe36023",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 36
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779485433260,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779485433260,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe40afb3a5eb1cfde05cbc01deafa45a56a4e7cb3": {
+      "profile_v1": {
+        "gold": 5,
+        "updatedAt": 1780889900844,
+        "lastKnownName": "CavinM",
+        "lifetimeStats": {
+          "wavesCleared": 86,
+          "matchesPlayed": 10,
+          "zombiesKilled": 1353
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780889900844,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2",
+            "gun_t3"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t3",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780889900844,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe3a0856066cbea6ef5528af2f00eae255bd84eb7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781271997370,
+        "lastKnownName": "Turron",
+        "lifetimeStats": {
+          "wavesCleared": 14,
+          "matchesPlayed": 2,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781271997370,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic",
+            "gun_t2"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t2",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781271997370,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe3825a10f512145a71dc72bbcbcb83c2efc283ea": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779792756896,
+        "lastKnownName": "EaxTest",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779792756896,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779792756896,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe3c40e0de6e24fcb64fa14b0c3f175aba78a40eb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780622006575,
+        "lastKnownName": "GEO",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 36
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780622006575,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780622006575,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe511c55ee31bb51297ec41b1a885420389b9a259": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780500616512,
+        "lastKnownName": "piguel",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780500616512,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780500616512,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe44ecce4e86c2263a093415da2bbdcecb1a4a1c6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779805067381,
+        "lastKnownName": "Kairos",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 2,
+          "zombiesKilled": 69
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779805067381,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779805067381,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe534c6d426fa3ddf7741bcf8dec221a5bca3f0a1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780579922604,
+        "lastKnownName": "Aster Starfall",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780579922604,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780579922604,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe6c91ec0a25ee69b89466157aad29528a06c74c7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780485927549,
+        "lastKnownName": "Sneferka",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780485927549,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780485927549,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe6eb66820edf5f6eaa498a7e0cd2a2579cbd1b9f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780837267627,
+        "lastKnownName": "wendeljr",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 8
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780837267627,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780837267627,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe7042bac2ac7cb9c654251e5c6c28ee15e6f2006": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780076814388,
+        "lastKnownName": "Cooper21",
+        "lifetimeStats": {
+          "wavesCleared": 9,
+          "matchesPlayed": 1,
+          "zombiesKilled": 121
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780076814388,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780076814388,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe71bfc3963ea6f06b99352d007359f958fca81d5": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780010932548,
+        "lastKnownName": "Craftsman",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 2,
+          "zombiesKilled": 90
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780010932548,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780010932548,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe740d34ba7efe979703b1ec546ed3dceba3200a6": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780262155141,
+        "lastKnownName": "0xe740d3",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780262155141,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780262155141,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe777c1d058a037764fedc7edeb8eee9d4fac8c92": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1777643076189,
+        "lastKnownName": "Elzath",
+        "lifetimeStats": {
+          "wavesCleared": 6,
+          "matchesPlayed": 1,
+          "zombiesKilled": 28
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1777643076189,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_basic"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1777643076189,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe81f6bc1aa7d7c6c2d5a2ba32d8a9baa23051a47": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780452761989,
+        "lastKnownName": "psg",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 32
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780452761989,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780452761989,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe7eb95f18aa9db5a072dc246043d7e820c6a1cc1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779520449235,
+        "lastKnownName": "Ricardo 12",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779520449235,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779520449235,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xe905f73427071e4db844ef95f9bab30e716e98cc": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781349470560,
+        "lastKnownName": "Santana Bang",
+        "lifetimeStats": {
+          "wavesCleared": 9,
+          "matchesPlayed": 3,
+          "zombiesKilled": 113
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781349470560,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781349470560,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xeacbd84d3ac37013be024769f7b1d7752533558a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779808670947,
+        "lastKnownName": "0xeacbd8",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 2,
+          "zombiesKilled": 11
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779808670947,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779808670947,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xea957147fd77329df30540970cc7a98b89c8802c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780168857354,
+        "lastKnownName": "Kira",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 15
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780168857354,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780168857354,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xeb0c682e1ca11e62eabe436ea36459d57616e5f1": {
+      "profile_v1": {
+        "gold": 3,
+        "updatedAt": 1780402412555,
+        "lastKnownName": "OtoLam",
+        "lifetimeStats": {
+          "wavesCleared": 15,
+          "matchesPlayed": 1,
+          "zombiesKilled": 257
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780402412555,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780402412555,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xeaf63aee520703bd3eb12599ed9bd930963e22d1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779695977633,
+        "lastKnownName": "g",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779695977633,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779695977633,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xeb3ab9f1388f5587ac30db93f5a27e0a0dc75a2a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780588650545,
+        "lastKnownName": "Mr7",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 3,
+          "zombiesKilled": 89
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780588650545,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780588650545,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xeba70cf32af4d26830c092f57efd53d11857aab5": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780290859546,
+        "lastKnownName": "chamaco loco777",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780290859546,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780290859546,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xebbe42e899c63cdeaeec9fc8dc1b6d96f4e4956c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780155503323,
+        "lastKnownName": "Nescau",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 12
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780155503323,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780155503323,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xebb0838b780fc3483c0974f83104a2a9aa37a7dc": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778390092711,
+        "lastKnownName": "kregg",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778390092711,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778390092712,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xebca4b89f56810462f41ca4e2e1985dcdf42f729": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780135935457,
+        "lastKnownName": "RandomGuy",
+        "lifetimeStats": {
+          "wavesCleared": 67,
+          "matchesPlayed": 5,
+          "zombiesKilled": 803
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780135935457,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1",
+            "gun_t2",
+            "gun_t3"
+          ],
+          "tier2": [
+            "shotgun_t1",
+            "shotgun_t2"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t3",
+          "tier2": "shotgun_t2",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780135935457,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xec8f6f8ff260dedcaa4eb1564d27d1ea613cf63b": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779773378136,
+        "lastKnownName": "Mich",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779773378136,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779773378136,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xec0f37385e5b1d1376d5f2d22ae5966177d95d1a": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780893610435,
+        "lastKnownName": "KarlaJudith",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 1,
+          "zombiesKilled": 30
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780893610435,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780893610435,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xebf0c6f9194a905c4b1e51ef720798a7cc898469": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779532559098,
+        "lastKnownName": "Nova Voidblade",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 16
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779532559098,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779532559098,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xeca412bac01dae2e0ddd3b63f9063a505936b62f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780698063869,
+        "lastKnownName": "santiagosadavid",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 2
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780698063869,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780698063869,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xed8f2ab4cf644ad1bab6adcd3a9745a948132f1d": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780456460952,
+        "lastKnownName": "Dominic",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780456460952,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780456460952,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xee31a7a792450889b48058bc424826e4e63bea08": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780460064671,
+        "lastKnownName": "67",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 25
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780460064671,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780460064671,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xef8c7b5422804f0219de6ddaa8a8799eef8c8a7e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780047541564,
+        "lastKnownName": "drawn",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 1
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780047541564,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780047541564,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xee84237aa7c25893b973c8d1abb51f73ef96e280": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779492750598,
+        "lastKnownName": "0xee8423",
+        "lifetimeStats": {
+          "wavesCleared": 4,
+          "matchesPlayed": 2,
+          "zombiesKilled": 45
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779492750598,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779492750598,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xed8fabe8e368d7dcbc1b352e4a5e09e76b61e5df": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779882172135,
+        "lastKnownName": "0xed8fab",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779882172135,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779882172135,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf017ba0a48e6ca8a220e767e9b0f1aca731bbd6f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779549094542,
+        "lastKnownName": "Danielkapp",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779549094542,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779549094542,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf0716303888dc77359f3e8b66dd8e44a00aadba2": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780002985201,
+        "lastKnownName": "Nova Frostborn",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 13
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780002985201,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780002985201,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf173199b453f25863f43392fa754fd5635a51a94": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781457530787,
+        "lastKnownName": "Lyra Nightwing",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 4
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781457530787,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781457530787,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf1335a4e14d38cedd5398645f6b69d1b6e8fa2de": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779483020633,
+        "lastKnownName": "lil g",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779483020633,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779483020633,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf24ca752a9ceafe8b508a09203f9ee35554511e3": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779540285876,
+        "lastKnownName": "PEDROVSK",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779540285876,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779540285876,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf183a5b20d2472d83efd20dd7c0ca16291e063fd": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780290840947,
+        "lastKnownName": "Iris Galewind",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780290840947,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780290840947,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf3906bded0d4f4465278e9672f1f5f6435e9eb8e": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780959836880,
+        "lastKnownName": "MANDRAGORA666",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 38
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780959836880,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780959836880,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf37dfb3250be2ff2284e193d8cf64ddbc9479967": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780986354279,
+        "lastKnownName": "NachoFriend187",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780986354279,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780986354279,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf60799e580555fea517637466543e236bf5d0a85": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780988572927,
+        "lastKnownName": "Bigcat515",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 26
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780988572927,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780988572927,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf5ac2ce98c280ffd2dc7bebc7eecc6888a8c53f4": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780132909017,
+        "lastKnownName": "OGis42",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 2,
+          "zombiesKilled": 109
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780132909017,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780132909017,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf4d4a4a2c2c7867a9769be085282800c4edadecb": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780823236254,
+        "lastKnownName": "devil",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 26
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780823236254,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780823236254,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf43d3b0434ce182faf5fbc2e09649f26a7b2cf7a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779837462528,
+        "lastKnownName": "miguel",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779837462528,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779837462529,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf679262617f2699c1926039497b276eaeb564928": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779744699773,
+        "lastKnownName": "Jumpnspid3r",
+        "lifetimeStats": {
+          "wavesCleared": 5,
+          "matchesPlayed": 3,
+          "zombiesKilled": 68
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779744699773,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779744699773,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf708233bd9670c6abd7825ec009836b692bdf4e7": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781243220353,
+        "lastKnownName": "GLOCKZADAS",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781243220354,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781243220354,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf741dbddd009e40b23642d8d2653e5e38dcc521c": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780895953954,
+        "lastKnownName": "Talia Nightsky",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 3
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780895953954,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780895953954,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf713b3edb656720b90fce18a8cb725f18319fee1": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780562144881,
+        "lastKnownName": "trixS2",
+        "lifetimeStats": {
+          "wavesCleared": 3,
+          "matchesPlayed": 1,
+          "zombiesKilled": 28
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780562144881,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780562144881,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf7651c2fb58adb937b658b78710e1011ddf3dd6f": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779827946962,
+        "lastKnownName": "Tarry",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779827946962,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779827946962,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf759388fe3c6dc3cb72274ee48a91cbf7b5aec64": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780633688573,
+        "lastKnownName": "Kai Raveneye",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 1,
+          "zombiesKilled": 4
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780633688573,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780633688573,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf766b1d9a6275744723df3e63eb33795258be819": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1781146044461,
+        "lastKnownName": "yHatter",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781146044461,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781146044461,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf7834d8a45d30cdf15a784d16ad49beda954c400": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1778457322993,
+        "lastKnownName": "Sugiharasan",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1778457322993,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1778457322993,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf8833bf212153bc12f3ac0c9e49312ac72a96f09": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780100946044,
+        "lastKnownName": "Jefferson 12383",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780100946045,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780100946045,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf7fa517af2d917145eb0dd8c1dbeb800e8c3f63a": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1773412690915,
+        "lastKnownName": "agus carriso",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 2,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1773412690915,
+        "ownedByTier": {
+          "tier1": [
+            "gun_basic"
+          ],
+          "tier2": [],
+          "tier3": [],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_basic",
+          "tier2": "",
+          "tier3": "",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1773412690915,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf86a330519e0837bb32f2f3b60a801f161d26c21": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780999498891,
+        "lastKnownName": "Waxine",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780999498891,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780999498891,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xf9ea171df6e2b58681c6b16a4a715185882f25a8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779503538647,
+        "lastKnownName": "td",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779503538647,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779503538647,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfb8a64eab1c7531d389eebc4dcf55911ae995635": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780880555149,
+        "lastKnownName": "Domble",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780880555149,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780880555149,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfba194c29dc9d7e5eaebdf32f7b7902f34ae88e8": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1779496360802,
+        "lastKnownName": "Nova Wolfbane",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 22
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1779496360802,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1779496360802,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfcf53519d9404589853964b98128d6ecffd05e28": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780298409925,
+        "lastKnownName": "Kmaginski00",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780298409925,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780298409925,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfc889dcbdf1050993004448c03ae72927bb85a51": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780047916819,
+        "lastKnownName": "Jade",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 7
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780047916819,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780047916819,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfbf7e572a63ca6a4e21a83720c0f23dd644e32e0": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780414279325,
+        "lastKnownName": "Chiri",
+        "lifetimeStats": {
+          "wavesCleared": 40,
+          "matchesPlayed": 7,
+          "zombiesKilled": 368
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780414279325,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1",
+            "shotgun_t2"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t2",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780414279325,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfce297d98aa290850695b0aeaae97549fbb917e0": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780064072442,
+        "lastKnownName": "0xfce297",
+        "lifetimeStats": {
+          "wavesCleared": 2,
+          "matchesPlayed": 1,
+          "zombiesKilled": 27
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780064072442,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780064072442,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfd399069305be6c6897a749159717e8c74f0a650": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1780665783839,
+        "lastKnownName": "Huevo2",
+        "lifetimeStats": {
+          "wavesCleared": 7,
+          "matchesPlayed": 2,
+          "zombiesKilled": 59
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780665783839,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780665783839,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfd25400ead2c327653ea4ce219592b6effd88e2f": {
+      "profile_v1": {
+        "gold": 1,
+        "updatedAt": 1781007125147,
+        "lastKnownName": "Kiss",
+        "lifetimeStats": {
+          "wavesCleared": 10,
+          "matchesPlayed": 1,
+          "zombiesKilled": 171
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1781007125147,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1781007125147,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfdcab1b36e036111b0cbfe02ac32e013cc5d5fe2": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780821893100,
+        "lastKnownName": "Thane Dawnblade",
+        "lifetimeStats": {
+          "wavesCleared": 11,
+          "matchesPlayed": 3,
+          "zombiesKilled": 126
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780821893100,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780821893100,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfdbc134cb8f2a639938eea23758469885508b3b0": {
+      "profile_v1": {
+        "gold": 5,
+        "updatedAt": 1780402222449,
+        "lastKnownName": "AdventureLand",
+        "lifetimeStats": {
+          "wavesCleared": 32,
+          "matchesPlayed": 3,
+          "zombiesKilled": 377
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780402222449,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780402222449,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfe7263ece3fa94947d5cb12e5e54d34bbf8d56e9": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780843101544,
+        "lastKnownName": "fateme",
+        "lifetimeStats": {
+          "wavesCleared": 0,
+          "matchesPlayed": 0,
+          "zombiesKilled": 0
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780843101545,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780843101545,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xfdbbe6160c14844167dfbcbef6f085c684fe4456": {
+      "profile_v1": {
+        "gold": 0,
+        "updatedAt": 1780429228135,
+        "lastKnownName": "wings",
+        "lifetimeStats": {
+          "wavesCleared": 1,
+          "matchesPlayed": 1,
+          "zombiesKilled": 10
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780429228135,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780429228135,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    },
+    "0xff3e27acdaa79f0f6198025fc24f1238ed62bcc7": {
+      "profile_v1": {
+        "gold": 2,
+        "updatedAt": 1780750504499,
+        "lastKnownName": "naylin",
+        "lifetimeStats": {
+          "wavesCleared": 15,
+          "matchesPlayed": 2,
+          "zombiesKilled": 152
+        },
+        "schemaVersion": 1
+      },
+      "weapons_v1": {
+        "updatedAt": 1780750504499,
+        "ownedByTier": {
+          "tier1": [
+            "gun_t1"
+          ],
+          "tier2": [
+            "shotgun_t1"
+          ],
+          "tier3": [
+            "minigun_t1"
+          ],
+          "tier4": []
+        },
+        "schemaVersion": 1,
+        "equippedByTier": {
+          "tier1": "gun_t1",
+          "tier2": "shotgun_t1",
+          "tier3": "minigun_t1",
+          "tier4": ""
+        }
+      },
+      "items_v1": {
+        "updatedAt": 1780750504499,
+        "ownedItemIds": [],
+        "schemaVersion": 1,
+        "equippedItemIds": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
In this PR:
Change productions name to official one.

Closes #320 