### PR TITLE
fix: closer mobile camera + larger tutorial UI size

### DIFF
--- a/src/debugFlags.ts
+++ b/src/debugFlags.ts
@@ -14,7 +14,7 @@ export const DEBUG_SHOW_GAMEPLAY_HUD_IN_LOBBY = false
 export const DEBUG_LOBBY_MATCH_WAVE = 9
 export const DEBUG_LOBBY_MATCH_ZOMBIES_LEFT = 23
 export const DEBUG_LOBBY_MATCH_PHASE_SECONDS = 18
-export const DEBUG_FORCE_TUTORIAL_MODE = true
+export const DEBUG_FORCE_TUTORIAL_MODE = false
 
 export const DEBUG_SHOP_UI_ONLY_LOADOUT: PlayerLoadoutSnapshot = {
   gold: 30,

--- a/src/debugFlags.ts
+++ b/src/debugFlags.ts
@@ -14,7 +14,7 @@ export const DEBUG_SHOW_GAMEPLAY_HUD_IN_LOBBY = false
 export const DEBUG_LOBBY_MATCH_WAVE = 9
 export const DEBUG_LOBBY_MATCH_ZOMBIES_LEFT = 23
 export const DEBUG_LOBBY_MATCH_PHASE_SECONDS = 18
-export const DEBUG_FORCE_TUTORIAL_MODE = false
+export const DEBUG_FORCE_TUTORIAL_MODE = true
 
 export const DEBUG_SHOP_UI_ONLY_LOADOUT: PlayerLoadoutSnapshot = {
   gold: 30,

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,7 @@ import { initArenaBackgroundMusicSystem } from './soundManager'
 import {
   getTutorialCameraFocusTarget,
   getTutorialCameraTransitionProgress,
-  initTutorialSystem,
-  shouldUseTutorialGameplayCloseCamera
+  initTutorialSystem
 } from './tutorial'
 import { getTutorialCoinCameraDebugState, getTutorialZombieCameraDebugState } from './tutorialCameraDebug'
 import { isTutorialActive } from './tutorialState'
@@ -103,8 +102,8 @@ const ISO_VIEW_DISTANCE = 8             // Diagonal distance from player — adj
 const ISO_VIEW_TILT_DEG = 55             // Angle looking down — adjust to taste
 const ISO_VIEW_SMOOTH_SPEED = 5
 const ISO_VIEW_DT_MAX = 1 / 30
-const ISO_VIEW_TUTORIAL_MOBILE_CLOSE_HEIGHT = 12.6
-const ISO_VIEW_TUTORIAL_MOBILE_CLOSE_DISTANCE = 6
+const ISO_VIEW_MOBILE_HEIGHT = 11
+const ISO_VIEW_MOBILE_DISTANCE = 5.5
 const ISO_VIEW_TUTORIAL_X_BIAS = 3.2
 const ISO_VIEW_TUTORIAL_Z_BIAS = -7.8
 const ISO_VIEW_TUTORIAL_YAW_BIAS_DEG = 7
@@ -213,7 +212,7 @@ function isoViewCameraSystem(dt: number) {
   const playerPos = Transform.get(engine.PlayerEntity).position
   const tutorialProgress = isTutorialActive() ? getTutorialCameraTransitionProgress() : 0
   const tutorialFocusTarget = isTutorialActive() ? getTutorialCameraFocusTarget() : null
-  const useTutorialMobileCloseCamera = isMobile() && shouldUseTutorialGameplayCloseCamera()
+  const mobileCamera = isMobile()
   const tutorialZombieCameraDebugState = getTutorialZombieCameraDebugState()
   const tutorialCoinCameraDebugState = getTutorialCoinCameraDebugState()
   const tutorialBiasX = tutorialFocusTarget
@@ -229,8 +228,8 @@ function isoViewCameraSystem(dt: number) {
   const focusBasePosition = tutorialFocusTarget
     ? Vector3.lerp(playerPos, tutorialFocusTarget.position, tutorialProgress)
     : playerPos
-  const baseIsoHeight = useTutorialMobileCloseCamera ? ISO_VIEW_TUTORIAL_MOBILE_CLOSE_HEIGHT : ISO_VIEW_HEIGHT
-  const baseIsoDistance = useTutorialMobileCloseCamera ? ISO_VIEW_TUTORIAL_MOBILE_CLOSE_DISTANCE : ISO_VIEW_DISTANCE
+  const baseIsoHeight = mobileCamera ? ISO_VIEW_MOBILE_HEIGHT : ISO_VIEW_HEIGHT
+  const baseIsoDistance = mobileCamera ? ISO_VIEW_MOBILE_DISTANCE : ISO_VIEW_DISTANCE
   const tutorialObjectHeight =
     tutorialFocusTarget?.kind === 'zombie'
       ? tutorialZombieCameraDebugState.height

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1207,7 +1207,7 @@ export const uiMenu = () => {
   const tutorialVirtualWidth = 1920
   const tutorialVirtualHeight = 1080
   const tutorialPanelSmallWidth = isMobileRuntime ? 620 : 590
-  const tutorialPanelLargeWidth = isMobileRuntime ? 760 : 900
+  const tutorialPanelLargeWidth = isMobileRuntime ? 836 : 900
   const tutorialRightColumnWidthRatio = isMobileRuntime ? 0.48 : 0.44
   const tutorialRightColumnWidth = isMobileRuntime ? '48%' : '44%'
   const tutorialPanelRightOffset = 1020


### PR DESCRIPTION
## Summary
- Unified the mobile iso camera for both arena and tutorial: both now use the same
  closer values (height: 11, distance: 5.5), slightly closer than the previous
  tutorial-only mobile close camera (12.6 / 6). Desktop camera is unchanged.
- Removed the `shouldUseTutorialGameplayCloseCamera` conditional — mobile always
  uses the close camera now, no special-casing per tutorial phase.
- Increased the non-split tutorial panel width by 10% on mobile (760 → 836).
  Only affects the first (card1) and last (card4) panels since they use the
  `center-large` layout. Height and all button hit areas scale proportionally.
- Enabled `DEBUG_FORCE_TUTORIAL_MODE` for testing.

## Test plan
- [ ] Mobile arena: confirm camera is closer than before and feels correct
- [ ] Mobile tutorial: confirm camera matches arena zoom throughout all phases
- [ ] Mobile tutorial card1 and card4: confirm panels are visibly larger and buttons still hit correctly
- [ ] Mobile tutorial card2 and card3 (split panels): confirm no size change
- [ ] Desktop: confirm camera and panel sizes are unchanged

Closes #327 
Closes #328 
