### PR TITLE
fix: make colliders bigger

### DIFF
--- a/src/arenaWalls.ts
+++ b/src/arenaWalls.ts
@@ -80,9 +80,7 @@ function arenaWallsSystem(): void {
         config.floorMinZ + config.floorSizeZ
       )
     }
-    for (const side of WALL_SIDES) {
-      const entity = engine.addEntity()
-      Transform.create(entity)
+    for (const [side, entity] of createWallSet()) {
       tutorialWallEntities.set(side, entity)
     }
   }

--- a/src/arenaWalls.ts
+++ b/src/arenaWalls.ts
@@ -1,19 +1,14 @@
 import { ColliderLayer, engine, Entity, MeshCollider, Transform } from '@dcl/sdk/ecs'
-import { Quaternion, Vector3 } from '@dcl/sdk/math'
-import { getCurrentRoomConfig } from './roomRuntime'
-import { getLobbyState, isLocalReadyForMatch } from './multiplayer/lobbyClient'
+import { Vector3 } from '@dcl/sdk/math'
+import { getArenaRoomConfig, ROOM_IDS, RoomId } from './shared/roomConfig'
+import { getTutorialArenaFloorBounds } from './tutorial'
 
 /**
- * Tall invisible colliders along the arena's visual wall perimeter.
+ * Tall invisible colliders along the arena wall perimeters (all 4 rooms + tutorial).
  *
- * The visual wall models already have physics colliders, but they are short
- * enough that players can jump/double-jump out of the arena. These boxes add the
- * missing height. They are only active DURING GAMEPLAY so players can still walk
- * freely in and out of the arena while in the lobby.
- *
- * The colliders are positioned at the current room's floor edges (the floor spans
- * exactly the walled area, see roomConfig.floor*), so they line up with the
- * visible walls regardless of which of the 4 rooms the local player is in.
+ * The visual wall models have short physics colliders that players can jump over.
+ * These boxes cover the full height and are always active so mobile players cannot
+ * exploit high lobby spots to jump into arenas.
  */
 
 const WALL_HEIGHT = 10
@@ -22,75 +17,91 @@ const WALL_THICKNESS = 0.5
 type WallSide = 'north' | 'south' | 'east' | 'west'
 const WALL_SIDES: WallSide[] = ['north', 'south', 'east', 'west']
 
-const wallEntityBySide = new Map<WallSide, Entity>()
-let entitiesCreated = false
-let wallsActive = false
+const wallEntitiesByRoom = new Map<RoomId, Map<WallSide, Entity>>()
+const tutorialWallEntities = new Map<WallSide, Entity>()
+let roomWallsReady = false
+let tutorialWallsPositioned = false
 
-function ensureWallEntities(): void {
-  if (entitiesCreated) return
+function createWallSet(): Map<WallSide, Entity> {
+  const map = new Map<WallSide, Entity>()
   for (const side of WALL_SIDES) {
     const entity = engine.addEntity()
     Transform.create(entity)
-    wallEntityBySide.set(side, entity)
+    map.set(side, entity)
   }
-  entitiesCreated = true
+  return map
 }
 
-/** Match-active signal: same check potions/collectibles use for "in the current match". */
-function isLocalPlayerInGameplay(): boolean {
-  const lobbyState = getLobbyState()
-  if (!lobbyState) return false
-  if (lobbyState.phase !== 'match_created') return false
-  return isLocalReadyForMatch()
-}
-
-function placeWall(side: WallSide, position: Vector3, scale: Vector3): void {
-  const entity = wallEntityBySide.get(side)
-  if (entity === undefined) return
-  const transform = Transform.getMutable(entity)
-  transform.position = position
-  transform.scale = scale
-  transform.rotation = Quaternion.Identity()
-}
-
-/** Position the four boxes around the current room's floor perimeter. */
-function positionWallsForCurrentRoom(): void {
-  const config = getCurrentRoomConfig()
-  const minX = config.floorMinX
-  const minZ = config.floorMinZ
-  const maxX = config.floorMinX + config.floorSizeX
-  const maxZ = config.floorMinZ + config.floorSizeZ
-  const centerX = config.arenaCenter.x
-  const centerZ = config.arenaCenter.z
-  const halfHeight = WALL_HEIGHT / 2
-
-  placeWall('south', Vector3.create(centerX, halfHeight, minZ), Vector3.create(config.floorSizeX, WALL_HEIGHT, WALL_THICKNESS))
-  placeWall('north', Vector3.create(centerX, halfHeight, maxZ), Vector3.create(config.floorSizeX, WALL_HEIGHT, WALL_THICKNESS))
-  placeWall('west', Vector3.create(minX, halfHeight, centerZ), Vector3.create(WALL_THICKNESS, WALL_HEIGHT, config.floorSizeZ))
-  placeWall('east', Vector3.create(maxX, halfHeight, centerZ), Vector3.create(WALL_THICKNESS, WALL_HEIGHT, config.floorSizeZ))
-}
-
-function setWallCollision(enabled: boolean): void {
-  for (const entity of wallEntityBySide.values()) {
-    if (enabled) {
-      MeshCollider.setBox(entity, ColliderLayer.CL_PHYSICS)
+function positionAndEnableWalls(
+  entities: Map<WallSide, Entity>,
+  centerX: number,
+  centerZ: number,
+  minX: number,
+  maxX: number,
+  minZ: number,
+  maxZ: number
+): void {
+  const halfHeight = WALL_HEIGHT / 2 + 4
+  const sizeX = maxX - minX
+  const sizeZ = maxZ - minZ
+  for (const [side, entity] of entities) {
+    const t = Transform.getMutable(entity)
+    if (side === 'south') {
+      t.position = Vector3.create(centerX, halfHeight, minZ)
+      t.scale = Vector3.create(sizeX, WALL_HEIGHT, WALL_THICKNESS)
+    } else if (side === 'north') {
+      t.position = Vector3.create(centerX, halfHeight, maxZ)
+      t.scale = Vector3.create(sizeX, WALL_HEIGHT, WALL_THICKNESS)
+    } else if (side === 'west') {
+      t.position = Vector3.create(minX, halfHeight, centerZ)
+      t.scale = Vector3.create(WALL_THICKNESS, WALL_HEIGHT, sizeZ)
     } else {
-      MeshCollider.deleteFrom(entity)
+      t.position = Vector3.create(maxX, halfHeight, centerZ)
+      t.scale = Vector3.create(WALL_THICKNESS, WALL_HEIGHT, sizeZ)
     }
+    MeshCollider.setBox(entity, ColliderLayer.CL_PHYSICS)
   }
 }
 
 function arenaWallsSystem(): void {
-  const shouldBeActive = isLocalPlayerInGameplay()
-  if (shouldBeActive === wallsActive) return
+  if (!roomWallsReady) {
+    roomWallsReady = true
+    for (const roomId of ROOM_IDS) {
+      const entities = createWallSet()
+      wallEntitiesByRoom.set(roomId, entities)
+      const config = getArenaRoomConfig(roomId)
+      positionAndEnableWalls(
+        entities,
+        config.arenaCenter.x,
+        config.arenaCenter.z,
+        config.floorMinX,
+        config.floorMinX + config.floorSizeX,
+        config.floorMinZ,
+        config.floorMinZ + config.floorSizeZ
+      )
+    }
+    for (const side of WALL_SIDES) {
+      const entity = engine.addEntity()
+      Transform.create(entity)
+      tutorialWallEntities.set(side, entity)
+    }
+  }
 
-  wallsActive = shouldBeActive
-  ensureWallEntities()
-  if (shouldBeActive) {
-    positionWallsForCurrentRoom()
-    setWallCollision(true)
-  } else {
-    setWallCollision(false)
+  if (!tutorialWallsPositioned) {
+    const bounds = getTutorialArenaFloorBounds()
+    if (bounds) {
+      tutorialWallsPositioned = true
+      const { centerX, centerZ, sizeX, sizeZ } = bounds
+      positionAndEnableWalls(
+        tutorialWallEntities,
+        centerX,
+        centerZ,
+        centerX - sizeX / 2,
+        centerX + sizeX / 2,
+        centerZ - sizeZ / 2,
+        centerZ + sizeZ / 2
+      )
+    }
   }
 }
 

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -193,7 +193,7 @@ export function getTutorialArenaFloorBounds(): { centerX: number; centerZ: numbe
   )
   const center = Vector3.add(rootTransform.position, Vector3.rotate(scaledFloorOffset, rootTransform.rotation))
   const sizeX = Math.abs(floorTransform.scale.x * rootTransform.scale.x)
-  const sizeZ = Math.abs(floorTransform.scale.y * rootTransform.scale.z)
+  const sizeZ = Math.abs(floorTransform.scale.y * rootTransform.scale.z) // Plane primitive: local Y maps to world Z
   return { centerX: center.x, centerZ: center.z, sizeX, sizeZ }
 }
 

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -179,6 +179,24 @@ function getTutorialArenaTransform(): {
   }
 }
 
+export function getTutorialArenaFloorBounds(): { centerX: number; centerZ: number; sizeX: number; sizeZ: number } | null {
+  const arenaEntity = findSceneEntity(EntityNames.arena_tutorial)
+  if (arenaEntity === null) return null
+  const rootTransform = Transform.getOrNull(arenaEntity)
+  const floorEntity = findTutorialArenaFloorEntity(arenaEntity)
+  const floorTransform = floorEntity !== null ? Transform.getOrNull(floorEntity) : null
+  if (!rootTransform || !floorTransform) return null
+  const scaledFloorOffset = Vector3.create(
+    floorTransform.position.x * rootTransform.scale.x,
+    floorTransform.position.y * rootTransform.scale.y,
+    floorTransform.position.z * rootTransform.scale.z
+  )
+  const center = Vector3.add(rootTransform.position, Vector3.rotate(scaledFloorOffset, rootTransform.rotation))
+  const sizeX = Math.abs(floorTransform.scale.x * rootTransform.scale.x)
+  const sizeZ = Math.abs(floorTransform.scale.y * rootTransform.scale.z)
+  return { centerX: center.x, centerZ: center.z, sizeX, sizeZ }
+}
+
 function setTutorialMovementLockPosition(position: Vector3): void {
   tutorialState.movementLockPosition = Vector3.create(position.x, position.y, position.z)
 }


### PR DESCRIPTION
## Summary
- Arena wall colliders (tall invisible boxes that prevent jumping out) are now
  always active for all 4 rooms instead of only during active gameplay. This
  prevents mobile players from exploiting high lobby spots to jump into arenas.
- Added the same tall colliders to the tutorial arena. They are positioned lazily
  (once the tutorial scene entity is available) using the floor entity's scale to
  derive the bounds.
- Collider base raised from y=0 to y=4 to match the actual arena wall geometry.
- Exported `getTutorialArenaFloorBounds()` from `tutorial.ts` to provide center
  and size of the tutorial arena floor to the wall system.

## Changes
- `src/arenaWalls.ts` — rewritten: creates walls for all 4 rooms + tutorial on
  first system tick, always enabled, no gameplay-state gating
- `src/tutorial.ts` — added `getTutorialArenaFloorBounds()` export

## Test plan
- [ ] Mobile: confirm players cannot jump from lobby into any of the 4 arenas
- [ ] Mobile: confirm players cannot jump from lobby into the tutorial arena
- [ ] Arena gameplay: confirm players cannot jump/double-jump out during a match
- [ ] Tutorial: confirm players cannot escape the tutorial arena
- [ ] Normal arena entry via teleport still works correctly

Closes #329 