### PR TITLE
fix: remove .zone

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - main
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Remove the push-to-main deploy trigger deploy now only runs on release or manual workflow_dispatch.

Closes #332 