### PR TITLE
fix: rage sound

### DIFF
--- a/src/playerHealth.ts
+++ b/src/playerHealth.ts
@@ -2,6 +2,7 @@ import { engine, Transform } from '@dcl/sdk/ecs'
 import { Vector3 } from '@dcl/sdk/math'
 import { movePlayerTo } from '~system/RestrictedActions'
 import { getCurrentRoomConfig } from './roomRuntime'
+import { isRaging } from './rageEffect'
 import { getServerTime } from './shared/timeSync'
 import { playDamageSound } from './soundManager'
 
@@ -113,7 +114,9 @@ export function getHealGlowEndTime(): number {
 function triggerDamageOverlay(damageTaken: number, nowMs: number): void {
   if (damageTaken <= 0) return
 
-  playDamageSound()
+  if (!isRaging()) {
+    playDamageSound()
+  }
   const normalizedDamage = Math.max(1, Math.floor(damageTaken))
   damageOverlayTriggeredAtMs = nowMs
   damageOverlayPeakAlpha = Math.min(


### PR DESCRIPTION
Fixed zombie hit audio so the player damage grunt no longer plays while Rage Mode is active. The sound is now only triggered when the player is actually vulnerable, preventing false damage feedback when the rage shield absorbs zombie attacks.

Closes #334 