### PR TITLE
fix: virtual cameras on mobile

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -636,6 +636,7 @@ async function resolveRuntimePlatform(): Promise<void> {
   } catch {
     isMobileRuntime = detectMobileUserAgent()
   }
+  applyUiRenderer()
 }
 
 function ServerLoadingPanel(props: {
@@ -753,12 +754,19 @@ function ServerLoadingPanel(props: {
   )
 }
 
+function applyUiRenderer(): void {
+  ReactEcsRenderer.setUiRenderer(uiMenu, {
+    virtualWidth: isMobileRuntime ? 1600 : 1920,
+    virtualHeight: isMobileRuntime ? 720 : 1080
+  })
+}
+
 export function setupUi() {
   if (!runtimePlatformLookupRequested) {
     runtimePlatformLookupRequested = true
     void resolveRuntimePlatform()
   }
-  ReactEcsRenderer.setUiRenderer(uiMenu, { virtualWidth: 1920, virtualHeight: 1080 })
+  applyUiRenderer()
 }
 
 function GameOverOverlay(props: { stats: GameOverStatsModel }) {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,4 +1,4 @@
-import ReactEcs, { ReactEcsRenderer, UiEntity } from '@dcl/sdk/react-ecs'
+import ReactEcs, { ReactEcsRenderer, ScreenInsetArea, UiEntity } from '@dcl/sdk/react-ecs'
 import { Color4 } from '@dcl/sdk/math'
 import { movePlayerTo } from '~system/RestrictedActions'
 import { getExplorerInformation } from '~system/Runtime'
@@ -1396,6 +1396,35 @@ const teamPanelNameWidth = isMobileRuntime ? 100 : 120
           texture: { src: BLOOD_DAMAGE_FRAME_TEXTURE_SRC, filterMode: 'bi-linear', wrapMode: 'clamp' }
         }}
       />
+      {combinedDamageOverlayAlpha > 0.01 && (
+        <UiEntity
+          uiTransform={{
+            width: '100%',
+            height: '100%',
+            positionType: 'absolute',
+            position: { left: 0, top: 0 }
+          }}
+          uiBackground={{
+            color: Color4.create(1, 1, 1, combinedDamageOverlayAlpha),
+            textureMode: 'stretch',
+            texture: { src: BLOOD_DAMAGE_FRAME_TEXTURE_SRC, filterMode: 'bi-linear', wrapMode: 'clamp' }
+          }}
+        />
+      )}
+      {showDeathBackdrop && (
+        <UiEntity
+          uiTransform={{
+            width: '100%',
+            height: '100%',
+            positionType: 'absolute',
+            position: { left: 0, top: 0 }
+          }}
+          uiBackground={{
+            color: Color4.create(0.08, 0.01, 0.01, showGameOverOverlay ? GAME_OVER_BACKDROP_ALPHA : DEATH_BACKDROP_ALPHA)
+          }}
+        />
+      )}
+      <ScreenInsetArea uiTransform={{ flexDirection: 'column', alignItems: 'center', justifyContent: 'flex-start' }}>
       {tutorialRightBackdropAlpha > 0.001 && (
         <UiEntity
           uiTransform={{
@@ -1527,34 +1556,6 @@ const teamPanelNameWidth = isMobileRuntime ? 100 : 120
             />
           </UiEntity>
         </UiEntity>
-      )}
-      {combinedDamageOverlayAlpha > 0.01 && (
-        <UiEntity
-          uiTransform={{
-            width: '100%',
-            height: '100%',
-            positionType: 'absolute',
-            position: { left: 0, top: 0 }
-          }}
-          uiBackground={{
-            color: Color4.create(1, 1, 1, combinedDamageOverlayAlpha),
-            textureMode: 'stretch',
-            texture: { src: BLOOD_DAMAGE_FRAME_TEXTURE_SRC, filterMode: 'bi-linear', wrapMode: 'clamp' }
-          }}
-        />
-      )}
-      {showDeathBackdrop && (
-        <UiEntity
-          uiTransform={{
-            width: '100%',
-            height: '100%',
-            positionType: 'absolute',
-            position: { left: 0, top: 0 }
-          }}
-          uiBackground={{
-            color: Color4.create(0.08, 0.01, 0.01, showGameOverOverlay ? GAME_OVER_BACKDROP_ALPHA : DEATH_BACKDROP_ALPHA)
-          }}
-        />
       )}
       {(rageActive || speedActive) && (
         <UiEntity
@@ -2780,6 +2781,7 @@ const teamPanelNameWidth = isMobileRuntime ? 100 : 120
           timeSeconds={currentGameTime}
         />
       )}
+    </ScreenInsetArea>
     </UiEntity>
   )
 }


### PR DESCRIPTION
# Title

**fix: virtual cameras on mobile**

# Summary

After a recent SDK update, DCL's new virtual camera handling caused UI elements to render smaller than before on mobile devices.

- `setUiRenderer` now uses a mobile-specific virtual canvas (`1600x720` instead of `1920x1080`), allowing fixed-size UI elements to scale up and match their previous on-screen size.
- Platform detection (`getExplorerInformation`) resolves asynchronously after the initial user agent-based guess. The UI renderer is now re-applied once the platform is confirmed, preventing the UI from remaining on the wrong canvas size if the initial detection was inaccurate.

# Test Plan

- [ ] Verify UI element sizes on the mobile Explorer match their pre-SDK-update appearance.
- [ ] Verify desktop/web UI remains unchanged (`1920x1080` canvas).
- [ ] Confirm there are no layout regressions when the initial platform detection is incorrect and later corrected.

Closes #339 