### PR TITLE
ft: sdk toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "dcl-project",
       "version": "1.0.0",
       "devDependencies": {
-        "@dcl/js-runtime": "7.24.4-28592331167.commit-697ce9e",
-        "@dcl/sdk": "7.24.4-28592331167.commit-697ce9e"
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/js-runtime/dcl-js-runtime-7.24.6-30053227284.commit-1a44e31.tgz",
+        "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/dcl-sdk-7.24.6-30053227284.commit-1a44e31.tgz"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.24.4-28592331167.commit-697ce9e",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.24.4-28592331167.commit-697ce9e.tgz",
-      "integrity": "sha512-tPfevJo4n2OjkiGiQle4FdpyjPjDqvwHVL9KfgmWukL+WM/3H4HAf1d7IbUSmegV+t9UtKYvxZz+PVtGMtyM2g==",
+      "version": "7.24.6-30053227284.commit-1a44e31",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/ecs/dcl-ecs-7.24.6-30053227284.commit-1a44e31.tgz",
+      "integrity": "sha512-tMlXUJ/93whObOVG2P16yolhK9OtNK2/ObMksbIflb0PoxfgR8CbyG1qXFQcSEznSiw79HSweUNI3/5fGWmtUQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.16.2.tgz",
-      "integrity": "sha512-ewSqwbpneK/EQGRH1w8P1XlZywSgBLcThvrUv53C/2adbwSoTLzB8gc3is2lKpkDnM5XCdpOJUGmX/KuK43xXg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.17.0.tgz",
+      "integrity": "sha512-0usTWnxx4vRe7vaT7Y5uAm2jiazsqaHJTqhakbE4X6q+f0Na7Zp2J+uiSjESTbJvYDnx0m6yJza4iVq8FNZyZw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/ecs": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.24.3.tgz",
-      "integrity": "sha512-nYZEuEYEzOOmIfx0foiku2NVSoPwci2F5tGDbyi7uNn1hCwkTG8z+gcWqsfg9VBqSCR0ikBW6aP9Y3ukib8Nnw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.24.5.tgz",
+      "integrity": "sha512-wu9MvDu5aM+bFBLqwY86W8tsR8dr82PtFy1gsY4VKSeTzYg4/CH6MovrWx9q/nUStUwsVIEEJYaZ4A57Gtb73A==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -285,16 +285,16 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@dcl/inspector/node_modules/glob": {
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -376,9 +376,9 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.24.4-28592331167.commit-697ce9e",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.24.4-28592331167.commit-697ce9e.tgz",
-      "integrity": "sha512-BWXesYT58J/Fu3tnwZumm57+87Pkq3f1ldC67v/sK7U/+PpyTC8tElrzQS9YSo47wgdz43vOGYXLbC8PzPRhSA==",
+      "version": "7.24.6-30053227284.commit-1a44e31",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/js-runtime/dcl-js-runtime-7.24.6-30053227284.commit-1a44e31.tgz",
+      "integrity": "sha512-K/BJGMS9daXJIiMiNALct9uwJknO5/Ngyv6AYStv2PcAhMjibAKWVL4bbsE2LX4I2tlmK7fGczzH46Y3A6W1wA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -422,9 +422,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-28050011172.commit-c96236d",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-28050011172.commit-c96236d.tgz",
-      "integrity": "sha512-Osksqww4UrUaeuCVqUe3G+4qsm4dF6FN3QZFaS9OPazXu46hmEgz3OHsDjq4ehZJLqikyBdjLHIyWglyD4sMpg==",
+      "version": "1.0.0-29286492043.commit-0010e70",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29286492043.commit-0010e70.tgz",
+      "integrity": "sha512-P50hvWLEqfy/z2QfKoK7gqbwWr6EOHLJ1casunG+btCLvV2X9a1GhxooRK5rTXZAAJmno/5g59GVbpVNdRhvNw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -453,13 +453,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.24.4-28592331167.commit-697ce9e",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.24.4-28592331167.commit-697ce9e.tgz",
-      "integrity": "sha512-lLlzIdUafAtd6sO3YgWM5peraK1RP/OZqEan2t6TCgEUUv/TxdeHtK6yGztuKyu91TGkHjcfEYHiE+Wgq3e6cA==",
+      "version": "7.24.6-30053227284.commit-1a44e31",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/react-ecs/dcl-react-ecs-7.24.6-30053227284.commit-1a44e31.tgz",
+      "integrity": "sha512-cJRXe0iYIw1K0ewbhiwKRSVFuAaOaaIqkC/joSR4Y4mocmANLq1pdJLHE7H4parPaHK8LrfQ/dqEr3iXnrpBXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.24.4-28592331167.commit-697ce9e",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/ecs/dcl-ecs-7.24.6-30053227284.commit-1a44e31.tgz",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -488,37 +488,37 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.24.4-28592331167.commit-697ce9e",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.24.4-28592331167.commit-697ce9e.tgz",
-      "integrity": "sha512-gp54wb787PrbCZXuVBiK9GcHGij6nwsiq2SnBtepLHAM9kVKGIQs2IhqKURbgfokjp4z4/Ft0SbnlaNgBNb9iQ==",
+      "version": "7.24.6-30053227284.commit-1a44e31",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/dcl-sdk-7.24.6-30053227284.commit-1a44e31.tgz",
+      "integrity": "sha512-Ns1kS1IiO6TdAyuKSngAIXW4qtKjV4lISkB5Sr987x7z+sR3kRqUICZ+y0TPvZLnkWtFm8ea9Z63k8tf5JB4tQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.24.4-28592331167.commit-697ce9e",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/ecs/dcl-ecs-7.24.6-30053227284.commit-1a44e31.tgz",
         "@dcl/ecs-math": "2.1.0",
         "@dcl/explorer": "1.0.164509-20240802172549.commit-fb95b9b",
-        "@dcl/js-runtime": "7.24.4-28592331167.commit-697ce9e",
-        "@dcl/react-ecs": "7.24.4-28592331167.commit-697ce9e",
-        "@dcl/sdk-commands": "7.24.4-28592331167.commit-697ce9e",
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/js-runtime/dcl-js-runtime-7.24.6-30053227284.commit-1a44e31.tgz",
+        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/react-ecs/dcl-react-ecs-7.24.6-30053227284.commit-1a44e31.tgz",
+        "@dcl/sdk-commands": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/dcl-sdk-commands-7.24.6-30053227284.commit-1a44e31.tgz",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.24.4-28592331167.commit-697ce9e",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.24.4-28592331167.commit-697ce9e.tgz",
-      "integrity": "sha512-J9mnSLN9+hzszgsci9IBhU9/X3MyC2ExrzyouHbNeZJvFqITdgYUo/Om4NqsxmYmxY+XlsvxYkp9dA1ab++h2g==",
+      "version": "7.24.6-30053227284.commit-1a44e31",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/dcl-sdk-commands-7.24.6-30053227284.commit-1a44e31.tgz",
+      "integrity": "sha512-I1lYM1wfXCw6MfLdRVH/ldK7C6G+l3Iv+0cWfy/I6Gzz0My/49XuvmJxAxfZyjgXdOVOdJcfcamiLv/VqE+5iQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.24.4-28592331167.commit-697ce9e",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/ecs/dcl-ecs-7.24.6-30053227284.commit-1a44e31.tgz",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "7.34.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-28050011172.commit-c96236d",
+        "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -569,6 +569,363 @@
       },
       "bin": {
         "protoc-gen-dcl_ts_proto": "protoc-gen-dcl_ts_proto"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/win32-x64": {
@@ -754,9 +1111,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -873,9 +1230,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1132,9 +1489,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1299,9 +1656,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1929,9 +2286,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -2036,6 +2393,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3918,9 +4290,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4032,9 +4404,9 @@
       }
     },
     "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "server-logs": "sdk-commands sdk-server-logs"
   },
   "devDependencies": {
-    "@dcl/sdk": "7.24.4-28592331167.commit-697ce9e",
-    "@dcl/js-runtime": "7.24.4-28592331167.commit-697ce9e"
+    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/dcl-sdk-7.24.6-30053227284.commit-1a44e31.tgz",
+    "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/chore/storage-service-usage-improvements/@dcl/js-runtime/dcl-js-runtime-7.24.6-30053227284.commit-1a44e31.tgz"
   },
   "engines": {
     "node": ">=16.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "strict": true,
+    "skipLibCheck": true,
     "typeRoots": [
       "node_modules",
       "node_modules/@dcl/sdk/node_modules",


### PR DESCRIPTION
## Summary
- Upgrade `@dcl/sdk` and `@dcl/js-runtime` to a branch build from `js-sdk-toolchain`'s `chore/storage-service-usage-improvements` (`7.24.6-30053227284.commit-1a44e31`), pulled from the SDK team CDN instead of the npm registry
- Add `skipLibCheck: true` to `tsconfig.json` to work around a `.d.ts` export issue in this branch build
- Regenerate `package-lock.json` accordingly

## Why
Validate the upstream storage caching improvements (`Storage.get/set/player.*`) ahead of the stable SDK release — the scene calls these frequently, so we want to confirm fewer redundant round-trips / skipped no-op writes before upgrading for real.

## Test plan
- [x] `npm install` completes cleanly
- [x] `npm run build` — type checking passes with no errors
- [ ] In-world testing of storage-heavy flows

## Notes
This pins to a temporary branch build for QA only, not a permanent dependency — revert to the standard `@dcl/sdk` release once the upstream PR ships
