### PR TITLE
ci: auto-deploy to .zone on every PR to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## What changed
Added a `pull_request` trigger (opened/synchronize/reopened, targeting `main`) to the `deploy.yml` workflow.

## Why
Every PR against `main` should automatically deploy to the testing environment (worlds-content-server.decentraland.zone) without manually triggering the deploy.

## How it works
`DEPLOY_ENV` already defaulted to `'testing'` for any event that isn't `release` or `workflow_dispatch`, so no extra logic was needed: when a PR is opened or updated against `main`, the job runs `npm run deploy:testing` automatically.

## Notes / limitations
- `secrets.DCL_WORLDS_PRIVATE_KEY` is not available on PRs from forks (standard GitHub Actions security behavior for `pull_request`). If external PRs are expected, we'd need `pull_request_target` or another approach.

## Test plan
- [ ] Open a test PR against `main` and confirm the "Deploy" job runs and publishes to `.zone`.
- [ ] Confirm a published `release` still deploys to production unchanged.

Closes #347 
